### PR TITLE
feat: accessToken 만료 시 refreshToken으로 새로운 토큰 발급 및 로그인 여부에 따른 리다이렉트 구현

### DIFF
--- a/lib/apis/auth/index.ts
+++ b/lib/apis/auth/index.ts
@@ -12,7 +12,7 @@ export async function login(
 ): Promise<PostTeamIdAuthSigninResponse | string> {
   try {
     const response = await fetch(
-      `${process.env.NEXT_PUBLIC_KKOM_KKOM_URL}/auth/signIn`,
+      `${process.env.NEXT_PUBLIC_KKOM_KKOM_URL}/auth/signin`,
       {
         method: "POST",
         headers: {

--- a/lib/apis/auth/index.ts
+++ b/lib/apis/auth/index.ts
@@ -12,7 +12,7 @@ export async function login(
 ): Promise<PostTeamIdAuthSigninResponse | string> {
   try {
     const response = await fetch(
-      `${process.env.NEXT_PUBLIC_KKOM_KKOM_URL}/auth/signin`,
+      `${process.env.NEXT_PUBLIC_KKOM_KKOM_URL}/auth/signIn`,
       {
         method: "POST",
         headers: {

--- a/middleware.ts
+++ b/middleware.ts
@@ -8,15 +8,12 @@ export function middleware(request: NextRequest, event: NextFetchEvent) {
   const hasRefreshToken = request.cookies.has("refreshToken");
   const { pathname } = request.nextUrl;
 
-  // NOTE - 로그인 후 랜딩, 로그인, 회원가입 페이지에 접근하는 경우
+  // NOTE - 로그인 후 로그인, 회원가입 페이지에 접근하는 경우
   if (
     hasAccessToken &&
-    (pathname.startsWith("/login") ||
-      pathname.startsWith("/signup") ||
-      pathname === "/")
+    (pathname.startsWith("/login") || pathname.startsWith("/signup"))
   ) {
-    // TODO - 어디로 리다이렉트 ??
-    return NextResponse.redirect(new URL("/addteam", request.url));
+    return NextResponse.redirect(new URL("/", request.url));
   }
 
   // NOTE - 로그인 전에 랜딩, 로그인, 회원가입 페이지 외에 다른 페이지에 접근하는 경우
@@ -68,7 +65,7 @@ export function middleware(request: NextRequest, event: NextFetchEvent) {
     event.waitUntil(fetchPromise);
 
     // 비동기 작업이 완료된 후 요청을 계속 진행하도록 합니다.
-    // 이때 `fetchPromise`에서 반환한 `NextResponse` 객체 사용
+    // 이때 fetchPromise에서 반환한 NextResponse 객체 사용
     return new Promise((resolve) => {
       fetchPromise.then((nextResponse) => {
         resolve(nextResponse);

--- a/middleware.ts
+++ b/middleware.ts
@@ -1,0 +1,84 @@
+import { NextResponse } from "next/server";
+import type { NextFetchEvent, NextRequest } from "next/server";
+
+import { PostTeamIdAuthRefreshTokenResponse } from "./lib/apis/type";
+
+export function middleware(request: NextRequest, event: NextFetchEvent) {
+  const hasAccessToken = request.cookies.has("accessToken");
+  const hasRefreshToken = request.cookies.has("refreshToken");
+  const { pathname } = request.nextUrl;
+
+  // NOTE - 로그인 후 랜딩, 로그인, 회원가입 페이지에 접근하는 경우
+  if (
+    hasAccessToken &&
+    (pathname.startsWith("/login") ||
+      pathname.startsWith("/signup") ||
+      pathname === "/")
+  ) {
+    // TODO - 어디로 리다이렉트 ??
+    return NextResponse.redirect(new URL("/addteam", request.url));
+  }
+
+  // NOTE - 로그인 전에 랜딩, 로그인, 회원가입 페이지 외에 다른 페이지에 접근하는 경우
+  if (
+    !hasAccessToken &&
+    !(
+      pathname.startsWith("/login") ||
+      pathname.startsWith("/signup") ||
+      pathname === "/"
+    )
+  ) {
+    return NextResponse.redirect(new URL("/login", request.url));
+  }
+
+  // NOTE - accessToken이 만료되어서 refreshToken을 통해 새로운 토큰을 발급해야 하는 경우
+  if (!hasAccessToken && hasRefreshToken) {
+    const refreshTokenValue = request.cookies.get("refreshToken")?.value;
+
+    // NOTE - Fetch를 사용하여 새로운 accessToken을 발급받는 비동기 작업
+    const fetchPromise = fetch(
+      `${process.env.NEXT_PUBLIC_KKOM_KKOM_URL}/auth/refresh-token`,
+      {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+        },
+        body: JSON.stringify({
+          refreshToken: refreshTokenValue,
+        }),
+      },
+    )
+      .then(async (response) => {
+        if (!response.ok) {
+          throw new Error("refresh token 요청 실패");
+        }
+        const data: PostTeamIdAuthRefreshTokenResponse = await response.json();
+
+        // NextResponse 객체를 만들어 쿠키를 설정
+        const nextResponse = NextResponse.next();
+        nextResponse.cookies.set("accessToken", data.accessToken);
+
+        return nextResponse;
+      })
+      .catch((error) => {
+        return NextResponse.redirect(new URL("/login", request.url));
+      });
+
+    // waitUntil을 사용하여 비동기 작업이 완료될 때까지 기다림
+    event.waitUntil(fetchPromise);
+
+    // 비동기 작업이 완료된 후 요청을 계속 진행하도록 합니다.
+    // 이때 `fetchPromise`에서 반환한 `NextResponse` 객체 사용
+    return new Promise((resolve) => {
+      fetchPromise.then((nextResponse) => {
+        resolve(nextResponse);
+      });
+    });
+  }
+
+  return NextResponse.next();
+}
+
+export const config = {
+  matcher: "/((?!api|_next/static|_next/image|favicon.ico).*)",
+};


### PR DESCRIPTION
## 🏷️ 이슈 번호 #70 

- close #70 

## 🧱 작업 사항
- refreshToken으로 accessToken을 재발급 받습니다.
- 로그인 여부에 따른 리다이렉트를 구현합니다. 
- 로그인 전에 랜딩, 로그인, 회원가입 페이지 외 접근하면 /login 으로 리다이렉트 ( / 가 나을까요 ??) 
- 로그인 후에 랜딩, 로그인, 회원가입 페이지에 접근하면 로그인 후 메인페이지 (지금은 저희가 그걸 [groupId] 로 정했어요) 
- 근데 [groupId]가 동적 라우팅이다 보니까 미들웨어에서 또 사용자의 그룹 리스트를 조회해야 하는 로직이 추가됩니다. ㅜ 
- 근데 로그인 후의 메인 페이지가 동적 라우팅보다는 변하지 않는 라우트가 좋을 거 같아요 .. 그래서 코드잇 측에서도 / 랜딩 페이지로 이동시키는 거 아닌가 싶어요 (로그인 후에 리다이렉트도 복잡스 ..) 
- 이건 한 번 같이 얘기해 보는 게 좋을 거 같습니동 

## 📸 결과물

## 💬 공유 포인트 및 논의 사항
