### PR TITLE
feat: 비밀번호 재설정 기능 구현 

### DIFF
--- a/app/(auth)/login/_components/login-form.tsx
+++ b/app/(auth)/login/_components/login-form.tsx
@@ -3,6 +3,7 @@
 import Button from "@/components/button/button";
 import { BasicInput } from "@/components/input-field/basic-input";
 import PasswordInput from "@/components/input-field/password-input";
+import { useCustomOverlay } from "@/hooks/use-custom-overlay";
 import { login } from "@/lib/apis/auth";
 import { loginSchema } from "@/schemas/auth";
 import { yupResolver } from "@hookform/resolvers/yup";
@@ -11,12 +12,17 @@ import Link from "next/link";
 import { useRouter } from "next/navigation";
 import { SubmitHandler, useForm } from "react-hook-form";
 
+import ModalSendEmail from "../../reset-password/_components/modal-send-email";
+
 export interface LoginInputValue {
   email: string;
   password: string;
 }
 
 export default function LoginForm() {
+  const modalSendEmailOverlay = useCustomOverlay(({ close }) => (
+    <ModalSendEmail close={close} />
+  ));
   const router = useRouter();
   const {
     register,
@@ -69,12 +75,13 @@ export default function LoginForm() {
           error={errors.password?.message}
         />
       </div>
-      <Link
-        href="/reset-password"
-        className="mt-3 flex justify-end text-sm font-medium text-brand-primary underline"
+      <button
+        type="button"
+        className="ml-auto mt-3 flex text-sm font-medium text-brand-primary underline"
+        onClick={modalSendEmailOverlay.open}
       >
         비밀번호를 잊으셨나요?
-      </Link>
+      </button>
       <Button
         btnSize="large"
         btnStyle="solid"

--- a/app/(auth)/login/_components/login-form.tsx
+++ b/app/(auth)/login/_components/login-form.tsx
@@ -70,7 +70,7 @@ export default function LoginForm() {
         />
       </div>
       <Link
-        href="/login"
+        href="/reset-password"
         className="mt-3 flex justify-end text-sm font-medium text-brand-primary underline"
       >
         비밀번호를 잊으셨나요?

--- a/app/(auth)/reset-password/_components/modal-send-email.tsx
+++ b/app/(auth)/reset-password/_components/modal-send-email.tsx
@@ -59,7 +59,7 @@ export default function ModalSendEmail({ close }: ModalSendEmailProps) {
             buttonDescription="링크 보내기"
             close={close}
             className="mt-6"
-            confirmBtnDisabled={!isValid}
+            disabled={!isValid}
           />
         </form>
       </div>

--- a/app/(auth)/reset-password/_components/modal-send-email.tsx
+++ b/app/(auth)/reset-password/_components/modal-send-email.tsx
@@ -1,5 +1,7 @@
 import { BasicInput } from "@/components/input-field/basic-input";
 import Modal from "@/components/modal/modal";
+import { sendEmail } from "@/lib/apis/user";
+import { showToast } from "@/lib/show-toast";
 import { sendEmailSchema } from "@/schemas/auth";
 import { yupResolver } from "@hookform/resolvers/yup";
 import { SubmitHandler, useForm } from "react-hook-form";
@@ -25,8 +27,15 @@ export default function ModalSendEmail({ close }: ModalSendEmailProps) {
 
   const handleClick: SubmitHandler<SendEmailInputValue> = async (data) => {
     console.log(data);
-    //const response = await login(data);
-    close();
+    const response = await sendEmail(data);
+    if (typeof response === "string") {
+      if (response.includes("이메일")) {
+        showToast("warning", <p>{response}</p>);
+      }
+    } else {
+      showToast("success", <p>{response.message}</p>);
+      close();
+    }
   };
   return (
     <Modal close={close} closeOnFocusOut>

--- a/app/(auth)/reset-password/_components/modal-send-email.tsx
+++ b/app/(auth)/reset-password/_components/modal-send-email.tsx
@@ -1,0 +1,58 @@
+import { BasicInput } from "@/components/input-field/basic-input";
+import Modal from "@/components/modal/modal";
+import { sendEmailSchema } from "@/schemas/auth";
+import { yupResolver } from "@hookform/resolvers/yup";
+import { SubmitHandler, useForm } from "react-hook-form";
+
+interface ModalSendEmailProps {
+  close: () => void;
+}
+
+export interface SendEmailInputValue {
+  email: string;
+}
+
+export default function ModalSendEmail({ close }: ModalSendEmailProps) {
+  const {
+    register,
+    handleSubmit,
+    setError,
+    formState: { errors, isValid },
+  } = useForm<SendEmailInputValue>({
+    resolver: yupResolver(sendEmailSchema),
+    mode: "onChange",
+  });
+
+  const handleClick: SubmitHandler<SendEmailInputValue> = async (data) => {
+    console.log(data);
+    //const response = await login(data);
+    close();
+  };
+  return (
+    <Modal close={close} closeOnFocusOut>
+      <div className="my-6">
+        <Modal.Title className="mb-2">비밀번호 재설정</Modal.Title>
+        <Modal.Description className="mb-4">
+          비밀번호 재설정 링크를 보내드립니다.
+        </Modal.Description>
+        <form onSubmit={handleSubmit(handleClick)}>
+          <BasicInput<SendEmailInputValue>
+            register={register}
+            id="email"
+            placeholder="이메일을 입력해 주세요"
+            type="email"
+            error={errors.email?.message}
+          />
+          <Modal.TwoButtonSection
+            closeBtnStyle="outlined"
+            confirmBtnStyle="solid"
+            buttonDescription="링크 보내기"
+            close={close}
+            className="mt-6"
+            confirmBtnDisabled={!isValid}
+          />
+        </form>
+      </div>
+    </Modal>
+  );
+}

--- a/app/(auth)/reset-password/_components/modal-send-email.tsx
+++ b/app/(auth)/reset-password/_components/modal-send-email.tsx
@@ -26,11 +26,12 @@ export default function ModalSendEmail({ close }: ModalSendEmailProps) {
   });
 
   const handleClick: SubmitHandler<SendEmailInputValue> = async (data) => {
-    console.log(data);
     const response = await sendEmail(data);
     if (typeof response === "string") {
       if (response.includes("이메일")) {
-        showToast("warning", <p>{response}</p>);
+        // NOTE - setError는 버튼 disabled 처리 위함
+        showToast("error", <p>{response}</p>);
+        setError("email", { type: "manual" });
       }
     } else {
       showToast("success", <p>{response.message}</p>);

--- a/app/(auth)/reset-password/_components/reset-password-form.tsx
+++ b/app/(auth)/reset-password/_components/reset-password-form.tsx
@@ -2,9 +2,12 @@
 
 import Button from "@/components/button/button";
 import PasswordInput from "@/components/input-field/password-input";
+import { useCustomOverlay } from "@/hooks/use-custom-overlay";
 import { resetPasswordSchema } from "@/schemas/auth";
 import { yupResolver } from "@hookform/resolvers/yup";
 import { SubmitHandler, useForm } from "react-hook-form";
+
+import ModalSendEmail from "./modal-send-email";
 
 export interface ResetPasswordInputValue {
   passwordConfirmation: string;
@@ -12,6 +15,9 @@ export interface ResetPasswordInputValue {
 }
 
 export default function ResetPasswordForm() {
+  const modalSendEmailOverlay = useCustomOverlay(({ close }) => (
+    <ModalSendEmail close={close} />
+  ));
   const {
     register,
     handleSubmit,
@@ -26,7 +32,8 @@ export default function ResetPasswordForm() {
   };
 
   return (
-    <form onSubmit={handleSubmit(onSubmit)}>
+    // <form onSubmit={handleSubmit(onSubmit)}>
+    <form>
       <div className="flex flex-col gap-6">
         <PasswordInput<ResetPasswordInputValue>
           id="password"
@@ -48,6 +55,8 @@ export default function ResetPasswordForm() {
         btnStyle="solid"
         className="mt-10 w-full"
         disabled={!isValid}
+        type="button"
+        onClick={modalSendEmailOverlay.open}
       >
         재설정
       </Button>

--- a/app/(auth)/reset-password/_components/reset-password-form.tsx
+++ b/app/(auth)/reset-password/_components/reset-password-form.tsx
@@ -2,12 +2,9 @@
 
 import Button from "@/components/button/button";
 import PasswordInput from "@/components/input-field/password-input";
-import { useCustomOverlay } from "@/hooks/use-custom-overlay";
 import { resetPasswordSchema } from "@/schemas/auth";
 import { yupResolver } from "@hookform/resolvers/yup";
 import { SubmitHandler, useForm } from "react-hook-form";
-
-import ModalSendEmail from "./modal-send-email";
 
 export interface ResetPasswordInputValue {
   passwordConfirmation: string;
@@ -15,9 +12,6 @@ export interface ResetPasswordInputValue {
 }
 
 export default function ResetPasswordForm() {
-  const modalSendEmailOverlay = useCustomOverlay(({ close }) => (
-    <ModalSendEmail close={close} />
-  ));
   const {
     register,
     handleSubmit,
@@ -32,8 +26,7 @@ export default function ResetPasswordForm() {
   };
 
   return (
-    // <form onSubmit={handleSubmit(onSubmit)}>
-    <form>
+    <form onSubmit={handleSubmit(onSubmit)}>
       <div className="flex flex-col gap-6">
         <PasswordInput<ResetPasswordInputValue>
           id="password"
@@ -55,8 +48,6 @@ export default function ResetPasswordForm() {
         btnStyle="solid"
         className="mt-10 w-full"
         disabled={!isValid}
-        type="button"
-        onClick={modalSendEmailOverlay.open}
       >
         재설정
       </Button>

--- a/app/(auth)/reset-password/_components/reset-password-form.tsx
+++ b/app/(auth)/reset-password/_components/reset-password-form.tsx
@@ -6,7 +6,7 @@ import { resetPassword } from "@/lib/apis/user";
 import { showToast } from "@/lib/show-toast";
 import { resetPasswordSchema } from "@/schemas/auth";
 import { yupResolver } from "@hookform/resolvers/yup";
-import { useRouter, useSearchParams } from "next/navigation";
+import { useRouter } from "next/navigation";
 import { SubmitHandler, useForm } from "react-hook-form";
 
 export interface ResetPasswordInputValue {
@@ -14,10 +14,12 @@ export interface ResetPasswordInputValue {
   password: string;
 }
 
-export default function ResetPasswordForm() {
+interface ResetPasswordFormProps {
+  token: string;
+}
+
+export default function ResetPasswordForm({ token }: ResetPasswordFormProps) {
   const router = useRouter();
-  const searchParams = useSearchParams();
-  const token = searchParams.get("token");
   const {
     register,
     handleSubmit,
@@ -27,13 +29,13 @@ export default function ResetPasswordForm() {
     mode: "onChange",
   });
 
-  const onSubmit: SubmitHandler<ResetPasswordInputValue> = async (data) => {
-    // NOTE - 메일에 첨부된 링크가 아닌 강제로 들어온 경우
-    if (!token) {
-      router.push("/login");
-      return;
-    }
+  // NOTE - 이메일로 전송된 링크가 아닌 /reset-password로 접근하는 경우
+  if (!token) {
+    router.push("/login");
+    return;
+  }
 
+  const onSubmit: SubmitHandler<ResetPasswordInputValue> = async (data) => {
     const response = await resetPassword({ ...data, token });
 
     // NOTE - 토큰 요휴시간(1시간)이 지난 경우

--- a/app/(auth)/reset-password/_components/reset-password-form.tsx
+++ b/app/(auth)/reset-password/_components/reset-password-form.tsx
@@ -49,7 +49,7 @@ export default function ResetPasswordForm() {
         className="mt-10 w-full"
         disabled={!isValid}
       >
-        로그인
+        재설정
       </Button>
     </form>
   );

--- a/app/(auth)/reset-password/_components/reset-password-form.tsx
+++ b/app/(auth)/reset-password/_components/reset-password-form.tsx
@@ -28,19 +28,20 @@ export default function ResetPasswordForm() {
   });
 
   const onSubmit: SubmitHandler<ResetPasswordInputValue> = async (data) => {
-    if (token) {
-      const response = await resetPassword({ ...data, token });
-      if (typeof response === "string") {
-        if (response.includes("토큰")) {
-          showToast("error", <p>{response}</p>);
-          router.push("/login");
-        }
-      } else {
-        showToast("success", <p>비밀번호가 변경되었습니다.</p>);
-        router.push("/login");
-      }
+    // NOTE - 메일에 첨부된 링크가 아닌 강제로 들어온 경우
+    if (!token) {
+      router.push("/login");
+      return;
+    }
+
+    const response = await resetPassword({ ...data, token });
+
+    // NOTE - 토큰 요휴시간(1시간)이 지난 경우
+    if (typeof response === "string" && response.includes("토큰")) {
+      showToast("error", <p>{response}</p>);
+      router.push("/login");
     } else {
-      // NOTE - 메일에 첨부된 링크가 아닌 강제로 들어온 경우
+      showToast("success", <p>비밀번호가 변경되었습니다.</p>);
       router.push("/login");
     }
   };

--- a/app/(auth)/reset-password/_components/reset-password-form.tsx
+++ b/app/(auth)/reset-password/_components/reset-password-form.tsx
@@ -2,8 +2,11 @@
 
 import Button from "@/components/button/button";
 import PasswordInput from "@/components/input-field/password-input";
+import { resetPassword } from "@/lib/apis/user";
+import { showToast } from "@/lib/show-toast";
 import { resetPasswordSchema } from "@/schemas/auth";
 import { yupResolver } from "@hookform/resolvers/yup";
+import { useRouter, useSearchParams } from "next/navigation";
 import { SubmitHandler, useForm } from "react-hook-form";
 
 export interface ResetPasswordInputValue {
@@ -12,6 +15,9 @@ export interface ResetPasswordInputValue {
 }
 
 export default function ResetPasswordForm() {
+  const router = useRouter();
+  const searchParams = useSearchParams();
+  const token = searchParams.get("token");
   const {
     register,
     handleSubmit,
@@ -22,7 +28,21 @@ export default function ResetPasswordForm() {
   });
 
   const onSubmit: SubmitHandler<ResetPasswordInputValue> = async (data) => {
-    console.log(data);
+    if (token) {
+      const response = await resetPassword({ ...data, token });
+      if (typeof response === "string") {
+        if (response.includes("토큰")) {
+          showToast("error", <p>{response}</p>);
+          router.push("/login");
+        }
+      } else {
+        showToast("success", <p>비밀번호가 변경되었습니다.</p>);
+        router.push("/login");
+      }
+    } else {
+      // NOTE - 메일에 첨부된 링크가 아닌 강제로 들어온 경우
+      router.push("/login");
+    }
   };
 
   return (

--- a/app/(auth)/reset-password/_components/reset-password-form.tsx
+++ b/app/(auth)/reset-password/_components/reset-password-form.tsx
@@ -1,0 +1,56 @@
+"use client";
+
+import Button from "@/components/button/button";
+import PasswordInput from "@/components/input-field/password-input";
+import { resetPasswordSchema } from "@/schemas/auth";
+import { yupResolver } from "@hookform/resolvers/yup";
+import { SubmitHandler, useForm } from "react-hook-form";
+
+export interface ResetPasswordInputValue {
+  passwordConfirmation: string;
+  password: string;
+}
+
+export default function ResetPasswordForm() {
+  const {
+    register,
+    handleSubmit,
+    formState: { errors, isValid },
+  } = useForm<ResetPasswordInputValue>({
+    resolver: yupResolver(resetPasswordSchema),
+    mode: "onChange",
+  });
+
+  const onSubmit: SubmitHandler<ResetPasswordInputValue> = async (data) => {
+    console.log(data);
+  };
+
+  return (
+    <form onSubmit={handleSubmit(onSubmit)}>
+      <div className="flex flex-col gap-6">
+        <PasswordInput<ResetPasswordInputValue>
+          id="password"
+          placeholder="비밀번호를 입력해 주세요"
+          label="새 비밀번호"
+          error={errors.password?.message}
+          register={register}
+        />
+        <PasswordInput<ResetPasswordInputValue>
+          id="passwordConfirmation"
+          placeholder="새 비밀번호를 다시 한 번 입력해 주세요"
+          label="비밀번호 확인"
+          error={errors.passwordConfirmation?.message}
+          register={register}
+        />
+      </div>
+      <Button
+        btnSize="large"
+        btnStyle="solid"
+        className="mt-10 w-full"
+        disabled={!isValid}
+      >
+        로그인
+      </Button>
+    </form>
+  );
+}

--- a/app/(auth)/reset-password/page.tsx
+++ b/app/(auth)/reset-password/page.tsx
@@ -1,12 +1,19 @@
 import ResetPasswordForm from "./_components/reset-password-form";
 
-export default function Page() {
+export default function Page({
+  searchParams,
+}: {
+  searchParams: {
+    [key: string]: string;
+  };
+}) {
+  const { token } = searchParams;
   return (
     <>
-      <h1 className="xl:text-[40px] mx-auto mb-6 text-center text-2xl font-medium text-text-primary md:mb-[80px]">
+      <h1 className="mx-auto mb-6 text-center text-2xl font-medium text-text-primary md:mb-[80px] xl:text-[40px]">
         비밀번호 재설정
       </h1>
-      <ResetPasswordForm />
+      <ResetPasswordForm token={token} />
     </>
   );
 }

--- a/app/(auth)/reset-password/page.tsx
+++ b/app/(auth)/reset-password/page.tsx
@@ -1,3 +1,12 @@
+import ResetPasswordForm from "./_components/reset-password-form";
+
 export default function Page() {
-  return <div></div>;
+  return (
+    <>
+      <h1 className="xl:text-[40px] mx-auto mb-6 text-center text-2xl font-medium text-text-primary md:mb-[80px]">
+        비밀번호 재설정
+      </h1>
+      <ResetPasswordForm />
+    </>
+  );
 }

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,37 +1,9 @@
-"use client";
-
-import Modal from "@/components/modal/modal";
-import { useCustomOverlay } from "@/hooks/use-custom-overlay";
-import { showToast } from "@/lib/show-toast";
 import Link from "next/link";
 
 export default function Home() {
-  const overlay1 = useCustomOverlay(({ close }) => (
-    <Modal close={close} closeOnFocusOut={false}>
-      <Modal.HeaderWithClose />
-      <Modal.Title>제목</Modal.Title>
-      <Modal.Description>난 예시다.</Modal.Description>
-      <Modal.Description>해냈다.</Modal.Description>
-      <button
-        onClick={() => {
-          setTimeout(() => {
-            // 패치
-            close();
-          }, 300);
-        }}
-      >
-        패치 후 닫기
-      </button>
-    </Modal>
-  ));
-
   return (
     <div className="w-full py-5">
       <div className="flex flex-col items-center gap-1">
-        <button onClick={overlay1.open}>나 버튼임 ㅎㅇ</button>
-        <button onClick={() => showToast("success", "성공했다.")}>
-          토스트
-        </button>
         <h1 className="text-3xl">랜딩페이지</h1>
         <Link href="/myhistory" className="text-text-primary">
           마이 히스토리로 이동

--- a/components/header/logged-in-header.tsx
+++ b/components/header/logged-in-header.tsx
@@ -14,7 +14,7 @@ export default async function LoggedInHeader() {
         {/* TODO - 클릭 시 사이드 메뉴 memberships 목록 + 자유게시판 */}
         <SideMenu />
         <Link href="/" className="flex items-center gap-1">
-          <div className="size-4 xl:size-6">
+          <div className="xl:size-6 size-4">
             <Logo width={"100%"} height={"100%"} />
           </div>
           <h2 className="text-xl font-bold text-brand-primary">KKOM-KKOM</h2>

--- a/components/modal/modal.tsx
+++ b/components/modal/modal.tsx
@@ -5,7 +5,12 @@ import useClickOutside from "@/hooks/use-click-outside";
 import { cn } from "@/lib/cn";
 import CloseButton from "@/public/icons/x.svg";
 import { motion } from "framer-motion";
-import { LegacyRef, createContext, useContext } from "react";
+import {
+  ButtonHTMLAttributes,
+  LegacyRef,
+  createContext,
+  useContext,
+} from "react";
 
 import {
   descriptionVariants,
@@ -160,14 +165,14 @@ function HeaderWithClose({ className }: HeaderWithCloseProps) {
 
 HeaderWithClose.displayName = "Modal.HeaderWithClose";
 
-interface TwoButtonSectionProps {
+interface TwoButtonSectionProps
+  extends ButtonHTMLAttributes<HTMLButtonElement> {
   buttonDescription: string;
   close: () => void;
   closeBtnStyle: "solid" | "outlined" | "outlined_secondary" | "danger";
   confirmBtnStyle: "solid" | "outlined" | "outlined_secondary" | "danger";
   onClick?: () => void;
   className?: string;
-  confirmBtnDisabled?: boolean;
 }
 
 function TwoButtonSection({
@@ -177,7 +182,7 @@ function TwoButtonSection({
   confirmBtnStyle,
   onClick,
   className,
-  confirmBtnDisabled,
+  ...rest
 }: TwoButtonSectionProps) {
   return (
     <section className={cn(twoButtonVariants({ className }))}>
@@ -195,7 +200,7 @@ function TwoButtonSection({
         btnStyle={confirmBtnStyle}
         className="flex-1"
         onClick={onClick}
-        disabled={confirmBtnDisabled}
+        {...rest}
       >
         {buttonDescription}
       </Button>

--- a/components/modal/modal.tsx
+++ b/components/modal/modal.tsx
@@ -167,6 +167,7 @@ interface TwoButtonSectionProps {
   confirmBtnStyle: "solid" | "outlined" | "outlined_secondary" | "danger";
   onClick?: () => void;
   className?: string;
+  confirmBtnDisabled?: boolean;
 }
 
 function TwoButtonSection({
@@ -176,6 +177,7 @@ function TwoButtonSection({
   confirmBtnStyle,
   onClick,
   className,
+  confirmBtnDisabled,
 }: TwoButtonSectionProps) {
   return (
     <section className={cn(twoButtonVariants({ className }))}>
@@ -193,6 +195,7 @@ function TwoButtonSection({
         btnStyle={confirmBtnStyle}
         className="flex-1"
         onClick={onClick}
+        disabled={confirmBtnDisabled}
       >
         {buttonDescription}
       </Button>

--- a/lib/apis/auth/index.ts
+++ b/lib/apis/auth/index.ts
@@ -25,7 +25,7 @@ export async function login(
     if (!response.ok) {
       const errorData = await response.json();
       if (response.status === 400) {
-        return errorData.message;
+        return errorData.details;
       }
       throw new Error("로그인을 다시 시도해 주세요");
     }

--- a/lib/apis/auth/index.ts
+++ b/lib/apis/auth/index.ts
@@ -30,11 +30,11 @@ export async function login(
       if (response.status === 400) {
         return errorData;
       }
-      throw new Error("로그인을 다시 시도해 주세요"); // 다른 에러는 던지기
+      throw new Error("로그인을 다시 시도해 주세요");
     }
 
     const result: PostTeamIdAuthSigninResponse = await response.json();
-    return result; // 로그인 성공 시 응답
+    return result;
   } catch (error) {
     if (error instanceof Error) {
       throw new Error(error.message);

--- a/lib/apis/auth/index.ts
+++ b/lib/apis/auth/index.ts
@@ -9,7 +9,10 @@ import {
 // NOTE - 로그인
 export async function login(
   data: LoginInputValue,
-): Promise<PostTeamIdAuthSigninResponse | string> {
+): Promise<
+  | PostTeamIdAuthSigninResponse
+  | { details: Record<string, { message: string }> }
+> {
   try {
     const response = await fetch(
       `${process.env.NEXT_PUBLIC_KKOM_KKOM_URL}/auth/signIn`,
@@ -25,17 +28,18 @@ export async function login(
     if (!response.ok) {
       const errorData = await response.json();
       if (response.status === 400) {
-        return errorData.details;
+        return errorData;
       }
-      throw new Error("로그인을 다시 시도해 주세요");
+      throw new Error("로그인을 다시 시도해 주세요"); // 다른 에러는 던지기
     }
-    const result: PostTeamIdAuthSignupResponse = await response.json();
-    return result;
+
+    const result: PostTeamIdAuthSigninResponse = await response.json();
+    return result; // 로그인 성공 시 응답
   } catch (error) {
     if (error instanceof Error) {
-      return error.message;
+      throw new Error(error.message);
     }
-    return "무슨 메세지를 리턴해야 함";
+    throw new Error("로그인을 다시 시도해 주세요");
   }
 }
 

--- a/lib/apis/user/index.ts
+++ b/lib/apis/user/index.ts
@@ -1,6 +1,11 @@
+import { SendEmailInputValue } from "@/app/(auth)/reset-password/_components/modal-send-email";
 import { getCookie } from "cookies-next";
 
-import { GetTeamIdUserGroups, GetTeamIdUserHistoryResponse } from "../type";
+import {
+  GetTeamIdUserGroups,
+  GetTeamIdUserHistoryResponse,
+  PostTeamIdUserSendResetPasswordEmailResponse,
+} from "../type";
 
 // NOTE - 유저가 포함한 그룹 조회
 export async function gerUserGroups(): Promise<GetTeamIdUserGroups> {
@@ -97,5 +102,42 @@ export async function getUserHistory(accessToken: string | undefined) {
     const errorMessage = await getErrorMessage(error, [401]);
     console.error(errorMessage);
     throw new Error(errorMessage);
+  }
+}
+
+// NOTE - 비밀번호 재설정 전 이메일 확인
+export async function sendEmail(
+  data: SendEmailInputValue,
+): Promise<PostTeamIdUserSendResetPasswordEmailResponse | string> {
+  const payload = {
+    ...data,
+    redirectUrl: "http://localhost:3000",
+  };
+  try {
+    const response = await fetch(
+      `${process.env.NEXT_PUBLIC_KKOM_KKOM_URL}/user/send-reset-password-email`,
+      {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+        },
+        body: JSON.stringify(payload),
+      },
+    );
+    if (!response.ok) {
+      const errorData = await response.json();
+      if (response.status === 400) {
+        return "존재하지 않는 이메일입니다.";
+      }
+      throw new Error("네트워크 에러 발생");
+    }
+    const result: PostTeamIdUserSendResetPasswordEmailResponse =
+      await response.json();
+    return result;
+  } catch (error) {
+    if (error instanceof Error) {
+      return error.message;
+    }
+    return "다시 시도해 주세요";
   }
 }

--- a/lib/apis/user/index.ts
+++ b/lib/apis/user/index.ts
@@ -74,8 +74,8 @@ async function getErrorMessage(error: unknown, statusCode: number[]) {
   if (error instanceof ResponseError) {
     // 내가 지정해놓은 에러 코드이고 통신이 온 경우
     if (statusCode.includes(error.response.status)) {
-      const data: { message: string } = await error.response.json();
-      return data.message;
+      const data = await error.response.json();
+      return data;
     }
     // 에러 코드로 지정되어 있지 않는데 통신은 온 경우
     return error.message;

--- a/lib/apis/user/index.ts
+++ b/lib/apis/user/index.ts
@@ -109,6 +109,7 @@ export async function getUserHistory(accessToken: string | undefined) {
 export async function sendEmail(
   data: SendEmailInputValue,
 ): Promise<PostTeamIdUserSendResetPasswordEmailResponse | string> {
+  console.log(">>>> sendEmail 실행");
   const payload = {
     ...data,
     redirectUrl: "http://localhost:3000",

--- a/middleware.ts
+++ b/middleware.ts
@@ -8,21 +8,24 @@ export function middleware(request: NextRequest, event: NextFetchEvent) {
   const hasRefreshToken = request.cookies.has("refreshToken");
   const { pathname } = request.nextUrl;
 
-  // NOTE - 로그인 후 로그인, 회원가입 페이지에 접근하는 경우
+  // NOTE - 로그인 후 로그인, 회원가입, 비밀번호 재설정 페이지에 접근하는 경우
   if (
     hasAccessToken &&
-    (pathname.startsWith("/login") || pathname.startsWith("/signup"))
+    (pathname.startsWith("/login") ||
+      pathname.startsWith("/signup") ||
+      pathname.startsWith("/reset"))
   ) {
     return NextResponse.redirect(new URL("/", request.url));
   }
 
-  // NOTE - 로그인 전에 랜딩, 로그인, 회원가입 페이지 외에 다른 페이지에 접근하는 경우
+  // NOTE - 로그인 전에 랜딩, 로그인, 회원가입, 비밀번호 재설정 페이지 외에 다른 페이지에 접근하는 경우
   if (
     !hasAccessToken &&
     !(
       pathname.startsWith("/login") ||
       pathname.startsWith("/signup") ||
-      pathname === "/"
+      pathname === "/" ||
+      pathname.startsWith("/reset")
     )
   ) {
     return NextResponse.redirect(new URL("/login", request.url));

--- a/middleware.ts
+++ b/middleware.ts
@@ -8,26 +8,20 @@ export function middleware(request: NextRequest, event: NextFetchEvent) {
   const hasRefreshToken = request.cookies.has("refreshToken");
   const { pathname } = request.nextUrl;
 
+  const isAuthPage =
+    pathname.startsWith("/login") ||
+    pathname.startsWith("/signup") ||
+    pathname.startsWith("/reset");
+
+  const isLandingPageOrAuthPage = pathname === "/" || isAuthPage;
+
   // NOTE - 로그인 후 로그인, 회원가입, 비밀번호 재설정 페이지에 접근하는 경우
-  if (
-    hasAccessToken &&
-    (pathname.startsWith("/login") ||
-      pathname.startsWith("/signup") ||
-      pathname.startsWith("/reset"))
-  ) {
+  if (hasAccessToken && isAuthPage) {
     return NextResponse.redirect(new URL("/", request.url));
   }
 
   // NOTE - 로그인 전에 랜딩, 로그인, 회원가입, 비밀번호 재설정 페이지 외에 다른 페이지에 접근하는 경우
-  if (
-    !hasAccessToken &&
-    !(
-      pathname.startsWith("/login") ||
-      pathname.startsWith("/signup") ||
-      pathname === "/" ||
-      pathname.startsWith("/reset")
-    )
-  ) {
+  if (!hasAccessToken && !isLandingPageOrAuthPage) {
     return NextResponse.redirect(new URL("/login", request.url));
   }
 

--- a/middleware.ts
+++ b/middleware.ts
@@ -50,7 +50,11 @@ export function middleware(request: NextRequest, event: NextFetchEvent) {
 
         // NextResponse 객체를 만들어 쿠키를 설정
         const nextResponse = NextResponse.next();
-        nextResponse.cookies.set("accessToken", data.accessToken);
+        nextResponse.cookies.set({
+          name: "accessToken",
+          value: data.accessToken,
+          maxAge: 60 * 60,
+        });
 
         return nextResponse;
       })

--- a/schemas/auth.ts
+++ b/schemas/auth.ts
@@ -52,3 +52,10 @@ export const resetPasswordSchema = yup.object().shape({
     .oneOf([yup.ref("password"), undefined], "비밀번호가 일치하지 않습니다.")
     .required("비밀번호 확인을 입력해 주세요"),
 });
+
+export const sendEmailSchema = yup.object().shape({
+  email: yup
+    .string()
+    .email("이메일 형식으로 작성해 주세요")
+    .required("이메일을 입력해 주세요"),
+});

--- a/schemas/auth.ts
+++ b/schemas/auth.ts
@@ -37,3 +37,18 @@ export const signUpSchema = yup.object().shape({
     .oneOf([yup.ref("password"), undefined], "비밀번호가 일치하지 않습니다.")
     .required("비밀번호 확인을 입력해 주세요"),
 });
+
+export const resetPasswordSchema = yup.object().shape({
+  password: yup
+    .string()
+    .min(8, "비밀번호는 최소 8자 이상입니다.")
+    .matches(
+      /^(?=.*[A-Za-z])(?=.*\d)(?=.*[!@#$%^&*])[A-Za-z\d!@#$%^&*]{8,}$/,
+      "비밀번호는 숫자, 영문, 특수문자(!@#$%^&*)를 포함해야 합니다.",
+    )
+    .required("비밀번호를 입력해 주세요"),
+  passwordConfirmation: yup
+    .string()
+    .oneOf([yup.ref("password"), undefined], "비밀번호가 일치하지 않습니다.")
+    .required("비밀번호 확인을 입력해 주세요"),
+});


### PR DESCRIPTION
## 🏷️ 이슈 번호 #82 

- close #82 

## 🧱 작업 사항

- 로그인 페이지에서 비밀번호를 잊으셨나요? 를 클릭하는 경우 이메일을 입력하는 모달 띄움
- 가입한 이력이 있는 이메일 입력 후 링크 보내기 클릭 시 해당 이메일로 메일 전송 
- 메일로 온 링크에 접속하면 배포링크(현재는 local 3000, 추후 배포 후 리다이렉트 url 변경 필요) reset-password 로 url에 토큰이 같이 담겨옴 
- 해당 토큰으로 비밀번호 업데이트 
- 성공 후 토스트와 login으로 리다이렉트 
- 토큰 만료 후 비밀번호 재설정 시도 시 에러 토스트와 login으로 리다이렉트 
- 메일로 첨부된 링크를 통해서가 아닌 url /reset-password 로 강제로 들어오는 경우 login으로 리다이렉트 (=토큰 없는 경우)


## 📸 결과물
![image](https://github.com/user-attachments/assets/6af3a6e0-7f2f-41a2-ad0b-60d10fe1404d)

![image](https://github.com/user-attachments/assets/6c499603-770e-4f48-8ad9-435a1e4da20c)
![image](https://github.com/user-attachments/assets/3f2d7da3-9962-4232-986c-c56030d9b804)


## 💬 공유 포인트 및 논의 사항
- 지금 리다이렉트 url이 local이라 테스트해 보시려면 pull 받아서 로컬에서 해야 할 거 같습니다 ㅠ 
- 추후 main에 반영할 때는 배포 url로 변경하고 빌드 환경에서는 local 3000으로 해야 할 거 같아요 !!
- 모달 너무너무 사용하기 편한 거 같아요 버튼 두 개 있는 것도 너무 알잘딱깔센 그 잡채 🌈👍🏻 
