### PR TITLE
refactor: myFetch로 리팩토링 

### DIFF
--- a/app/(auth)/login/_components/login-form.tsx
+++ b/app/(auth)/login/_components/login-form.tsx
@@ -3,6 +3,7 @@
 import Button from "@/components/button/button";
 import { BasicInput } from "@/components/input-field/basic-input";
 import PasswordInput from "@/components/input-field/password-input";
+import { useCustomOverlay } from "@/hooks/use-custom-overlay";
 import { login } from "@/lib/apis/auth";
 import { PostTeamIdAuthSigninResponse } from "@/lib/apis/type";
 import { loginSchema } from "@/schemas/auth";
@@ -12,12 +13,17 @@ import Link from "next/link";
 import { useRouter } from "next/navigation";
 import { SubmitHandler, useForm } from "react-hook-form";
 
+import ModalSendEmail from "../../reset-password/_components/modal-send-email";
+
 export interface LoginInputValue {
   email: string;
   password: string;
 }
 
 export default function LoginForm() {
+  const modalSendEmailOverlay = useCustomOverlay(({ close }) => (
+    <ModalSendEmail close={close} />
+  ));
   const router = useRouter();
   const {
     register,
@@ -75,12 +81,13 @@ export default function LoginForm() {
           error={errors.password?.message}
         />
       </div>
-      <Link
-        href="/login"
-        className="mt-3 flex justify-end text-sm font-medium text-brand-primary underline"
+      <button
+        type="button"
+        className="ml-auto mt-3 flex text-sm font-medium text-brand-primary underline"
+        onClick={modalSendEmailOverlay.open}
       >
         비밀번호를 잊으셨나요?
-      </Link>
+      </button>
       <Button
         btnSize="large"
         btnStyle="solid"

--- a/app/action.ts
+++ b/app/action.ts
@@ -1,5 +1,6 @@
 "use server";
 
+import { getErrorMessage, myFetch } from "@/lib/apis";
 import { GetTeamIdUserResponse } from "@/lib/apis/type";
 import { getCookie } from "cookies-next";
 import { cookies } from "next/headers";
@@ -10,7 +11,7 @@ export async function getUser(): Promise<GetTeamIdUserResponse> {
   const accessToken = getAccessToken();
 
   try {
-    const response = await fetch(
+    const response = await myFetch(
       `${process.env.NEXT_PUBLIC_KKOM_KKOM_URL}/user`,
       {
         method: "GET",
@@ -20,13 +21,11 @@ export async function getUser(): Promise<GetTeamIdUserResponse> {
       },
     );
 
-    if (!response.ok) {
-      throw new Error("네트워크 오류 발생");
-    }
-
     const data: GetTeamIdUserResponse = await response.json();
     return data;
   } catch (error) {
-    throw error;
+    const errorMessage = await getErrorMessage(error, []);
+
+    throw new Error(errorMessage || "네트워크 오류 발생");
   }
 }

--- a/components/header/group-dropdown.tsx
+++ b/components/header/group-dropdown.tsx
@@ -6,7 +6,6 @@ import Kebab from "@/public/icons/kebab-small.svg";
 import Plus from "@/public/icons/plus.svg";
 import hamster from "@/public/images/hamster.jpg";
 import Image from "next/image";
-import { usePathname } from "next/navigation";
 import { useRouter } from "next/navigation";
 import { useState } from "react";
 
@@ -18,7 +17,6 @@ interface GroupDropdownProps {
 }
 
 export default function GroupDropdown({ memberships }: GroupDropdownProps) {
-  const pathname = usePathname();
   const router = useRouter();
   const [selectedGroupId, setSelectedGroupId] = useState(
     memberships[0].group.id,

--- a/lib/apis/auth/index.ts
+++ b/lib/apis/auth/index.ts
@@ -44,7 +44,7 @@ export async function signUp(
   data: SignUpInputValue,
 ): Promise<PostTeamIdAuthSignupResponse | string> {
   try {
-    const response = await fetch(
+    const response = await myFetch(
       `${process.env.NEXT_PUBLIC_KKOM_KKOM_URL}/auth/signUp`,
       {
         method: "POST",
@@ -55,19 +55,15 @@ export async function signUp(
       },
     );
 
-    if (!response.ok) {
-      const errorData = await response.json();
-      if (response.status === 400) {
-        return errorData.message;
-      }
-      throw new Error("회원가입을 다시 시도해 주세요");
-    }
     const result: PostTeamIdAuthSignupResponse = await response.json();
     return result;
   } catch (error) {
-    if (error instanceof Error) {
-      return error.message;
+    const errorMessage = await getErrorMessage(error, [400]);
+
+    if (error instanceof ResponseError && error.response.status === 400) {
+      return errorMessage.message;
     }
-    return "회원가입을 다시 시도해 주세요";
+
+    return errorMessage || "회원가입을 다시 시도해 주세요";
   }
 }

--- a/lib/apis/auth/index.ts
+++ b/lib/apis/auth/index.ts
@@ -1,6 +1,7 @@
 import { LoginInputValue } from "@/app/(auth)/login/_components/login-form";
 import { SignUpInputValue } from "@/app/(auth)/signup/_components/signup-form";
 
+import { ResponseError, getErrorMessage, myFetch } from "..";
 import {
   PostTeamIdAuthSigninResponse,
   PostTeamIdAuthSignupResponse,
@@ -14,7 +15,7 @@ export async function login(
   | { details: Record<string, { message: string }> }
 > {
   try {
-    const response = await fetch(
+    const response = await myFetch(
       `${process.env.NEXT_PUBLIC_KKOM_KKOM_URL}/auth/signIn`,
       {
         method: "POST",
@@ -25,21 +26,16 @@ export async function login(
       },
     );
 
-    if (!response.ok) {
-      const errorData = await response.json();
-      if (response.status === 400) {
-        return errorData;
-      }
-      throw new Error("로그인을 다시 시도해 주세요");
-    }
-
     const result: PostTeamIdAuthSigninResponse = await response.json();
     return result;
   } catch (error) {
-    if (error instanceof Error) {
-      throw new Error(error.message);
+    const errorMessage = await getErrorMessage(error, [400]);
+
+    if (error instanceof ResponseError && error.response.status === 400) {
+      return errorMessage;
     }
-    throw new Error("로그인을 다시 시도해 주세요");
+
+    throw new Error(errorMessage || "로그인을 다시 시도해 주세요");
   }
 }
 

--- a/lib/apis/index.ts
+++ b/lib/apis/index.ts
@@ -2,7 +2,7 @@
  * 임시 에러 클래스입니다. 실제 API가 완성되면 수정해야 합니다.
  * @returns
  */
-class ResponseError extends Error {
+export class ResponseError extends Error {
   response: Response;
   constructor(message: string, res: Response) {
     // Error(message)를 만듭니다.

--- a/lib/apis/index.ts
+++ b/lib/apis/index.ts
@@ -1,0 +1,51 @@
+/**
+ * 임시 에러 클래스입니다. 실제 API가 완성되면 수정해야 합니다.
+ * @returns
+ */
+class ResponseError extends Error {
+  response: Response;
+  constructor(message: string, res: Response) {
+    // Error(message)를 만듭니다.
+    super(message);
+    // Error(message).response에 에러 만들 때 넣어놓은 res를 넣습니다.
+    this.response = res;
+  }
+}
+
+/**
+ * 임시 패치입니다. 실제 API가 완성되면 수정해야 합니다.
+ * @returns
+ */
+export async function myFetch(
+  input: string | URL | globalThis.Request,
+  init?: RequestInit,
+) {
+  const res = await fetch(input, init);
+  // status가 200 ~ 299 사이가 아니거나 통신을 받아올 수 없으면 에러를 던집니다.
+  if (!res.ok) {
+    throw new ResponseError("에러가 발생했습니다.", res);
+  }
+  return res;
+}
+
+/**
+ * 에러 메시지를 반환하는 함수
+ *
+ * @param error unknown
+ * @returns
+ */
+export async function getErrorMessage(error: unknown, statusCode: number[]) {
+  if (error instanceof ResponseError) {
+    // 내가 지정해놓은 에러 코드이고 통신이 온 경우
+    if (statusCode.includes(error.response.status)) {
+      const data = await error.response.json();
+      return data;
+    }
+    // 에러 코드로 지정되어 있지 않는데 통신은 온 경우
+    return error.message;
+  } else {
+    // 기타 통신을 받아올 수 없는 경우 등등
+    if (error instanceof Error) return error.message;
+    return String(error);
+  }
+}

--- a/lib/apis/user/index.ts
+++ b/lib/apis/user/index.ts
@@ -1,7 +1,7 @@
 import { SendEmailInputValue } from "@/app/(auth)/reset-password/_components/modal-send-email";
 import { getCookie } from "cookies-next";
 
-import { getErrorMessage, myFetch } from "..";
+import { ResponseError, getErrorMessage, myFetch } from "..";
 import {
   GetTeamIdUserGroups,
   GetTeamIdUserHistoryResponse,
@@ -65,7 +65,7 @@ export async function sendEmail(
     redirectUrl: "http://localhost:3000",
   };
   try {
-    const response = await fetch(
+    const response = await myFetch(
       `${process.env.NEXT_PUBLIC_KKOM_KKOM_URL}/user/send-reset-password-email`,
       {
         method: "POST",
@@ -75,21 +75,17 @@ export async function sendEmail(
         body: JSON.stringify(payload),
       },
     );
-    if (!response.ok) {
-      const errorData = await response.json();
-      if (response.status === 400) {
-        return "존재하지 않는 이메일입니다.";
-      }
-      throw new Error("네트워크 에러 발생");
-    }
+
     const result: PostTeamIdUserSendResetPasswordEmailResponse =
       await response.json();
     return result;
   } catch (error) {
-    if (error instanceof Error) {
-      return error.message;
+    const errorMessage = await getErrorMessage(error, [400]);
+    if (error instanceof ResponseError && error.response.status === 400) {
+      return "존재하지 않는 이메일입니다.";
     }
-    return "다시 시도해 주세요";
+
+    return errorMessage || "다시 시도해 주세요";
   }
 }
 

--- a/lib/apis/user/index.ts
+++ b/lib/apis/user/index.ts
@@ -1,6 +1,7 @@
 import { SendEmailInputValue } from "@/app/(auth)/reset-password/_components/modal-send-email";
 import { getCookie } from "cookies-next";
 
+import { getErrorMessage, myFetch } from "..";
 import {
   GetTeamIdUserGroups,
   GetTeamIdUserHistoryResponse,
@@ -31,58 +32,6 @@ export async function gerUserGroups(): Promise<GetTeamIdUserGroups> {
     return result;
   } catch (error) {
     throw error;
-  }
-}
-
-/**
- * 임시 에러 클래스입니다. 실제 API가 완성되면 수정해야 합니다.
- * @returns
- */
-class ResponseError extends Error {
-  response: Response;
-  constructor(message: string, res: Response) {
-    // Error(message)를 만듭니다.
-    super(message);
-    // Error(message).response에 에러 만들 때 넣어놓은 res를 넣습니다.
-    this.response = res;
-  }
-}
-
-/**
- * 임시 패치입니다. 실제 API가 완성되면 수정해야 합니다.
- * @returns
- */
-async function myFetch(
-  input: string | URL | globalThis.Request,
-  init?: RequestInit,
-) {
-  const res = await fetch(input, init);
-  // status가 200 ~ 299 사이가 아니거나 통신을 받아올 수 없으면 에러를 던집니다.
-  if (!res.ok) {
-    throw new ResponseError("에러가 발생했습니다.", res);
-  }
-  return res;
-}
-
-/**
- * 에러 메시지를 반환하는 함수
- *
- * @param error unknown
- * @returns
- */
-async function getErrorMessage(error: unknown, statusCode: number[]) {
-  if (error instanceof ResponseError) {
-    // 내가 지정해놓은 에러 코드이고 통신이 온 경우
-    if (statusCode.includes(error.response.status)) {
-      const data = await error.response.json();
-      return data;
-    }
-    // 에러 코드로 지정되어 있지 않는데 통신은 온 경우
-    return error.message;
-  } else {
-    // 기타 통신을 받아올 수 없는 경우 등등
-    if (error instanceof Error) return error.message;
-    return String(error);
   }
 }
 

--- a/lib/apis/user/index.ts
+++ b/lib/apis/user/index.ts
@@ -96,7 +96,7 @@ export async function resetPassword(data: {
 }): Promise<PatchTeamIdUserResetPasswordResponse | string> {
   console.log("ddds", data);
   try {
-    const response = await fetch(
+    const response = await myFetch(
       `${process.env.NEXT_PUBLIC_KKOM_KKOM_URL}/user/reset-password`,
       {
         method: "PATCH",
@@ -107,18 +107,14 @@ export async function resetPassword(data: {
       },
     );
 
-    if (!response.ok) {
-      if (response.status === 400) {
-        return "토큰이 만료 되었습니다. 다시 시도해 주세요";
-      }
-      throw new Error("다시 시도해 주세요");
-    }
     const result: PatchTeamIdUserResetPasswordResponse = await response.json();
     return result;
   } catch (error) {
-    if (error instanceof Error) {
-      return error.message;
+    const errorMessage = await getErrorMessage(error, [400]);
+    if (error instanceof ResponseError && error.response.status === 400) {
+      return "토큰이 만료 되었습니다. 다시 시도해 주세요";
     }
-    return "다시 시도해 주세요";
+
+    return errorMessage || "다시 시도해 주세요";
   }
 }


### PR DESCRIPTION
## 🏷️ 이슈 번호 #94 

- close #94 

## 🧱 작업 사항
- `login`
- `signUp`
- `sendEmail`
- `resetPassword`
- `getUser`
- 를 fetch에서 myFetch로 리팩토링하였습니다. 
- 에러 핸들링 너무 편해요 굿굿 !! 👍🏻이제 myFetch 쓰면 될 거 같아요 ~~ 
- 로그인 페이지에서  비밀번호를 잊으셨나요? 클릭 시 모달 다시 복구해놨읍니다ㅎㅎ 

## 📸 결과물

## 💬 공유 포인트 및 논의 사항
