### PR TITLE
feat: 모바일 사이드바 구현

### DIFF
--- a/components/header/group-dropdown.tsx
+++ b/components/header/group-dropdown.tsx
@@ -46,7 +46,7 @@ export default function GroupDropdown({ memberships }: GroupDropdownProps) {
                 onClick={() => handleSelect(membership.group.id)}
               >
                 <div className="flex items-center gap-3">
-                  <div className="relative size-8 rounded-md">
+                  <div className="relative size-8 overflow-hidden rounded-md">
                     {/* TODO - 이미지 없는 경우 기본 이미지 */}
                     <Image
                       src={membership.group.image || hamster}

--- a/components/header/logged-in-header.tsx
+++ b/components/header/logged-in-header.tsx
@@ -12,9 +12,9 @@ export default async function LoggedInHeader() {
     <>
       <div className="flex items-center gap-4">
         {/* TODO - 클릭 시 사이드 메뉴 memberships 목록 + 자유게시판 */}
-        <SideMenu />
+        <SideMenu memberships={memberships} />
         <Link href="/" className="flex items-center gap-1">
-          <div className="xl:size-6 size-4">
+          <div className="size-4 xl:size-6">
             <Logo width={"100%"} height={"100%"} />
           </div>
           <h2 className="text-xl font-bold text-brand-primary">KKOM-KKOM</h2>

--- a/components/header/modal-side-menu.tsx
+++ b/components/header/modal-side-menu.tsx
@@ -1,0 +1,61 @@
+"use client";
+
+import useClickOutside from "@/hooks/use-click-outside";
+import { Membership } from "@/lib/apis/type";
+import Plus from "@/public/icons/plus.svg";
+import CloseButton from "@/public/icons/x.svg";
+import hamster from "@/public/images/hamster.jpg";
+import { motion } from "framer-motion";
+import Image from "next/image";
+import Link from "next/link";
+import { LegacyRef } from "react";
+
+interface ModalSideMenuProps {
+  close: () => void;
+  memberships: Membership[];
+}
+export default function ModalSideMenu({
+  close,
+  memberships,
+}: ModalSideMenuProps) {
+  const modalRef = useClickOutside(() => {
+    close();
+  });
+  return (
+    <section className="fixed inset-0 z-40 flex bg-black bg-opacity-50">
+      <motion.div
+        ref={modalRef as LegacyRef<HTMLDivElement> | undefined}
+        className="relative h-full w-1/2 bg-background-secondary"
+      >
+        <button onClick={close} className="absolute right-4 top-4">
+          <CloseButton width={24} height={24} />
+        </button>
+        <ul className="mt-[75px] flex flex-col gap-6 px-4 text-sm font-medium text-text-primary">
+          {memberships.map((membership) => (
+            <li key={membership.group.id} className="flex items-center gap-3">
+              <div className="relative size-6 rounded-md">
+                {/* TODO - 기본 이미지 바꾸기 */}
+                <Image
+                  src={membership.group.image || hamster}
+                  alt={`${membership.group.name} 이미지`}
+                  fill
+                />
+              </div>
+              <p> {membership.group.name} 팀</p>
+            </li>
+          ))}
+          <li className="flex items-center gap-3" onClick={close}>
+            {/* <Plus width={18} height={18} /> */}
+            🌈
+            <Link href="/addteam">팀 추가하기</Link>
+          </li>
+          <li className="flex items-center gap-3" onClick={close}>
+            {/* <Plus width={18} height={18} /> */}
+            📋
+            <Link href="/boards">자유게시판</Link>
+          </li>
+        </ul>
+      </motion.div>
+    </section>
+  );
+}

--- a/components/header/modal-side-menu.tsx
+++ b/components/header/modal-side-menu.tsx
@@ -45,7 +45,7 @@ export default function ModalSideMenu({
               className="flex items-center gap-3"
               onClick={() => handleRoute(membership.group.id)}
             >
-              <div className="relative size-6 rounded-md">
+              <div className="relative size-6 overflow-hidden rounded-md">
                 {/* TODO - 기본 이미지 바꾸기 */}
                 <Image
                   src={membership.group.image || hamster}

--- a/components/header/modal-side-menu.tsx
+++ b/components/header/modal-side-menu.tsx
@@ -8,6 +8,7 @@ import hamster from "@/public/images/hamster.jpg";
 import { motion } from "framer-motion";
 import Image from "next/image";
 import Link from "next/link";
+import { useRouter } from "next/navigation";
 import { LegacyRef } from "react";
 
 interface ModalSideMenuProps {
@@ -18,9 +19,16 @@ export default function ModalSideMenu({
   close,
   memberships,
 }: ModalSideMenuProps) {
+  const router = useRouter();
   const modalRef = useClickOutside(() => {
     close();
   });
+
+  const handleRoute = (id: number) => {
+    router.push(`/${id}`);
+    close();
+  };
+
   return (
     <section className="fixed inset-0 z-40 flex bg-black bg-opacity-50">
       <motion.div
@@ -32,7 +40,11 @@ export default function ModalSideMenu({
         </button>
         <ul className="mt-[75px] flex flex-col gap-6 px-4 text-sm font-medium text-text-primary">
           {memberships.map((membership) => (
-            <li key={membership.group.id} className="flex items-center gap-3">
+            <li
+              key={membership.group.id}
+              className="flex items-center gap-3"
+              onClick={() => handleRoute(membership.group.id)}
+            >
               <div className="relative size-6 rounded-md">
                 {/* TODO - 기본 이미지 바꾸기 */}
                 <Image

--- a/components/header/side-menu.tsx
+++ b/components/header/side-menu.tsx
@@ -1,11 +1,22 @@
 "use client";
 
+import { useCustomOverlay } from "@/hooks/use-custom-overlay";
+import { Membership } from "@/lib/apis/type";
 import Menu from "@/public/icons/gnb-menu.svg";
 
-export default function SideMenu() {
+import ModalSideMenu from "./modal-side-menu";
+
+interface SideMenuProps {
+  memberships: Membership[];
+}
+
+export default function SideMenu({ memberships }: SideMenuProps) {
+  const modalSideMenuOverlay = useCustomOverlay(({ close }) => (
+    <ModalSideMenu close={close} memberships={memberships} />
+  ));
   // TODO - 사이드 메뉴 열기
   return (
-    <div className="md:hidden" onClick={() => alert("사이드 메뉴 open")}>
+    <div className="md:hidden" onClick={modalSideMenuOverlay.open}>
       <Menu width={24} height={24} />
     </div>
   );


### PR DESCRIPTION
## 🏷️ 이슈 번호 #83 

- close #83 

## 🧱 작업 사항
- 모바일에서 햄버거? 아이콘 클릭 시 나타나는 사이드바 입니다. 
- 승현님이 구현하신 useCustomOverlay 를 사용했습니다.👍🏻✨ 
- 메뉴 클릭 시 페이지 이동과 함께 사이드바가 닫히도록 했습니다
- 기존 피그마가 너무 심심해서 팀 목록은 팀 사진(없으면 기본이미지) , 자유게시판이랑 팀 추가하기 앞에 이모지 추가해놨어요 ㅎ.. 그래도 심심한데 추가되면 좋을 거 같은 디자인 추천 받습니도 .. 
- 모달 컴포넌트 참고해서 구현했는데 이렇게 만드는 게 맞나유..? 


## 📸 결과물
참여한 팀 있는 경우 
![image](https://github.com/user-attachments/assets/bb24bd10-214d-4fef-8875-236984a9bd30)

참여한 팀 없는 경우
![image](https://github.com/user-attachments/assets/e419be51-418c-4c90-82bb-fa7fd43951e4)



## 💬 공유 포인트 및 논의 사항
