### PR TITLE
feat: 팝오버에 클릭이벤트 추가

### DIFF
--- a/app/[groupId]/_components/team.tsx
+++ b/app/[groupId]/_components/team.tsx
@@ -1,3 +1,5 @@
+"use client";
+
 import Popover from "@/components/popover/popover";
 import Gear from "@/public/icons/gear.svg";
 import Thumbnail from "@/public/images/thumbnail-team.png";
@@ -6,7 +8,17 @@ import Image from "next/image";
 interface TeamProps {
   teamName: string;
 }
-const CONTENT = ["수정하기", "삭제하기"];
+
+const content = [
+  {
+    text: "수정하기",
+    onClick: () => console.log("수정하기 클릭"),
+  },
+  {
+    text: "삭제하기",
+    onClick: () => console.log("삭제하기 클릭"),
+  },
+];
 
 const Team = ({ teamName }: TeamProps) => {
   return (
@@ -20,7 +32,7 @@ const Team = ({ teamName }: TeamProps) => {
           triggerSvg={Gear}
           triggerHeight={24}
           triggerWidth={24}
-          content={CONTENT}
+          content={content}
           contentClassName="z-10 border-[1px] absolute right-0 bg-background-secondary border-border-primary/10 w-[120px] h-[80px] text-white"
         />
       </div>

--- a/app/[groupId]/_components/team.tsx
+++ b/app/[groupId]/_components/team.tsx
@@ -9,17 +9,6 @@ interface TeamProps {
   teamName: string;
 }
 
-const content = [
-  {
-    text: "수정하기",
-    onClick: () => console.log("수정하기 클릭"),
-  },
-  {
-    text: "삭제하기",
-    onClick: () => console.log("삭제하기 클릭"),
-  },
-];
-
 const Team = ({ teamName }: TeamProps) => {
   return (
     <div className="flex h-[64px] w-full items-center justify-between rounded-[12px] border-[1px] border-border-primary/10 bg-border-primary/10 pl-[24px]">
@@ -32,7 +21,10 @@ const Team = ({ teamName }: TeamProps) => {
           triggerSvg={Gear}
           triggerHeight={24}
           triggerWidth={24}
-          content={content}
+          content={[
+            { text: "수정하기", onClick: () => console.log("수정하기 클릭") },
+            { text: "삭제하기", onClick: () => console.log("삭제하기 클릭") },
+          ]}
           contentClassName="z-10 border-[1px] absolute right-0 bg-background-secondary border-border-primary/10 w-[120px] h-[80px] text-white"
         />
       </div>

--- a/app/[groupId]/tasks/_components/comment.tsx
+++ b/app/[groupId]/tasks/_components/comment.tsx
@@ -12,7 +12,7 @@ const Comment = () => {
             ㄴㄴㅇㅇㅇㅇㅇㅇㅇㅇㅇㅇㅇㅇㅇㅇㅇㅇㅇㅇㅇㅇㅇㅇㅇㅇㅇㅇㅇㅇㅇㅇㅇㅇㅇㅇㅇㅇㅇㅇㄴㄴㄴㄴㄴㄴㄴㄴㄴㄴㄴㄴㄴㄴㄴㄴㄴㄴㄴㄴㄴㄴㄴㄴㄴㄴㄴㄴㄴㄴ
           </p>
           <Popover
-            content={["취소", "수정하기"]}
+            content={[{ text: "취소" }, { text: "수정하기" }]}
             triggerWidth={16}
             triggerHeight={16}
             triggerSvg={Kebab}

--- a/components/header/popover-trigger.tsx
+++ b/components/header/popover-trigger.tsx
@@ -16,7 +16,20 @@ export default function PopoverTrigger({ nickname }: PopoverTriggerProps) {
         triggerSvg={UserIcon}
         triggerHeight={24}
         triggerWidth={24}
-        content={LOGGED_IN_USER_CONTENT}
+        content={[
+          {
+            text: LOGGED_IN_USER_CONTENT[0],
+          },
+          {
+            text: LOGGED_IN_USER_CONTENT[1],
+          },
+          {
+            text: LOGGED_IN_USER_CONTENT[2],
+          },
+          {
+            text: LOGGED_IN_USER_CONTENT[3],
+          },
+        ]}
         triggerText={nickname}
         triggerClassName="text-sm font-medium text-text-primary"
         contentClassName="z-10 border-[1px] bg-background-secondary border-border-primary/10 w-[120px] h-[160px] text-white text-sm font-normal mt-3 md:w-[135px] md:h-[184px] md:text-base"

--- a/components/popover/popover.tsx
+++ b/components/popover/popover.tsx
@@ -25,6 +25,10 @@ const PopoverContent = React.forwardRef<
 ));
 PopoverContent.displayName = PopoverPrimitive.Content.displayName;
 
+interface PopoverContentItem {
+  text: string;
+  onClick: () => void;
+}
 interface PopoverProps {
   triggerImage?: string | StaticImageData;
   triggerImageAlt?: string;
@@ -32,7 +36,7 @@ interface PopoverProps {
   triggerText?: string;
   triggerWidth?: number;
   triggerHeight?: number;
-  content: string[];
+  content: PopoverContentItem[];
   className?: string;
   triggerClassName?: string;
   contentClassName?: string;
@@ -46,11 +50,21 @@ interface PopoverProps {
    * @param triggerText : trigger 텍스트를 입력합니다.
    * @param triggerWidth : trigger image의 width를 입력합니다.
    * @param triggerHeight : trigger image의 height를 입력합니다.
-   * @param content : content에 들어갈 텍스트를 입력합니다.
+   * @param content : content에 들어갈 텍스트와 각 content의 onClick 이벤트를 입력합니다.
    * @param triggerClassName : trigger에 필요한 추가적인 css를 입력합니다.
    * @param contentClassName : content에 필요한 추가적인 css를 입력합니다.
    * @returns 팝오버 컴포넌트를 반환합니다.
    * @example
+   * const content = [
+      {
+        text: "수정하기",
+        onClick: () => console.log("수정하기 클릭"),
+      },
+      {
+        text: "삭제하기",
+        onClick: () => console.log("삭제하기 클릭"),
+      },
+    ];
    * <Popover
             triggerImage={hamster}
             triggerImageAlt="hamster"
@@ -74,8 +88,14 @@ const Popover = ({
   triggerClassName,
   contentClassName,
 }: PopoverProps) => {
+  const [open, setOpen] = React.useState(false);
+
+  const handleClose = () => {
+    setOpen(false);
+  };
+
   return (
-    <PopOver>
+    <PopOver open={open} onOpenChange={setOpen}>
       <div className={`${className}`}>
         <PopoverTrigger>
           <div
@@ -101,8 +121,15 @@ const Popover = ({
           className={`${contentClassName} flex flex-col items-center justify-center border-0 shadow-none`}
         >
           {content.map((item, index) => (
-            <button className="h-full w-full" key={index}>
-              {item}
+            <button
+              className="h-full w-full"
+              key={index}
+              onClick={() => {
+                item.onClick();
+                handleClose();
+              }}
+            >
+              {item.text}
             </button>
           ))}
         </PopoverContent>

--- a/components/popover/popover.tsx
+++ b/components/popover/popover.tsx
@@ -26,7 +26,7 @@ const PopoverContent = React.forwardRef<
 PopoverContent.displayName = PopoverPrimitive.Content.displayName;
 
 interface PopoverContentItem {
-  text: string;
+  text: string | string[];
   onClick?: () => void;
 }
 interface PopoverProps {
@@ -55,23 +55,16 @@ interface PopoverProps {
    * @param contentClassName : content에 필요한 추가적인 css를 입력합니다.
    * @returns 팝오버 컴포넌트를 반환합니다.
    * @example
-   * const content = [
-      {
-        text: "수정하기",
-        onClick: () => console.log("수정하기 클릭"),
-      },
-      {
-        text: "삭제하기",
-        onClick: () => console.log("삭제하기 클릭"),
-      },
-    ];
    * <Popover
             triggerImage={hamster}
             triggerImageAlt="hamster"
             triggerText="나는야햄스터"
             triggerWidth={30}
             triggerHeight={30}
-            content={content}
+            content={[
+            { text: "수정하기", onClick: () => console.log("수정하기 클릭") },
+            { text: "삭제하기", onClick: () => console.log("삭제하기 클릭") },
+            ]}
             triggerClassName="bg-pink-200 w-[150px] h-[50px]"
             contentClassName="left-[-77px] h-[100px] w-[200px] bg-yellow-200"
           />

--- a/components/popover/popover.tsx
+++ b/components/popover/popover.tsx
@@ -27,7 +27,7 @@ PopoverContent.displayName = PopoverPrimitive.Content.displayName;
 
 interface PopoverContentItem {
   text: string;
-  onClick: () => void;
+  onClick?: () => void;
 }
 interface PopoverProps {
   triggerImage?: string | StaticImageData;
@@ -125,7 +125,7 @@ const Popover = ({
               className="h-full w-full"
               key={index}
               onClick={() => {
-                item.onClick();
+                item.onClick && item.onClick();
                 handleClose();
               }}
             >


### PR DESCRIPTION
<!-- PR 제목은 커밋 메세지 컨벤션 형식으로 작성 -->

## 🏷️ 이슈 번호 #99 

- close #99 

## 🧱 작업 사항
- popover 컴포넌트의 각 content에 onClick 이벤트를 추가할 수 있도록 프롭을 추가하였습니다.
- content를 클릭하면 popover가 닫히도록 하였습니다.
   - popover trigger 클릭, popover content 클릭, popover 외부 클릭했을 때 popover가 닫힙니다.

## 📸 결과물

https://github.com/user-attachments/assets/3389ae11-666a-4e6a-b0cb-2fa66e1de947


## 💬 공유 포인트 및 논의 사항
좀 더 깔끔하게 구현하고 싶은데 map 함수를 써서 이 방법밖에 생각이 안 나네요😭😭
### 🚨 프롭이 바껴서 popover 쓰이는 모든 부분에서 content에 에러가 나서 text만 수정을 했는데 한번씩 확인 부탁드립니다!!