### PR TITLE
fix: enabled를 사용하여 특정타입외의 값으로 접근하면 함수 호출을 방지

### DIFF
--- a/app/[groupId]/tasks/_components/side-bar.tsx
+++ b/app/[groupId]/tasks/_components/side-bar.tsx
@@ -14,8 +14,8 @@ import PageButton from "./tasks-button";
 
 interface SideBarProps {
   gropId: string;
-  taskListId: number;
-  todoId: number;
+  taskListId: number | undefined;
+  todoId: number | undefined;
   handleCancelButton: () => void;
   isOpen: boolean;
 }

--- a/app/[groupId]/tasks/_components/todo/todo-box.tsx
+++ b/app/[groupId]/tasks/_components/todo/todo-box.tsx
@@ -25,7 +25,7 @@ const TodoBox = ({
   handleClickTodoBox,
   dateString,
 }: TodoBoxProps) => {
-  const convertedDateToYMD = convertDateToYMD(new Date(dateString));
+  const { year, month, day } = convertDateToYMD(new Date(dateString));
 
   return (
     <div
@@ -59,7 +59,9 @@ const TodoBox = ({
       </div>
       <div className="flex items-center gap-[10px]">
         <Calendar width={16} height={16} />
-        <p className="text-xs text-text-default">{convertedDateToYMD}</p>
+        <p className="text-xs text-text-default">
+          {year}년 {month}월 {day}일
+        </p>
         <Time width={16} height={16} />
         <p className="text-xs text-text-default">오후 3:30</p>
         <Repeat width={16} height={16} />

--- a/app/[groupId]/tasks/_components/todo/todo-list-name.tsx
+++ b/app/[groupId]/tasks/_components/todo/todo-list-name.tsx
@@ -2,7 +2,7 @@ import React, { ButtonHTMLAttributes, useState } from "react";
 
 interface TodoListNameProps extends ButtonHTMLAttributes<HTMLButtonElement> {
   buttonName: string;
-  selectedButton: number;
+  selectedButton: number | undefined;
 }
 
 const TodoListName = ({
@@ -13,7 +13,7 @@ const TodoListName = ({
   return (
     <button
       {...rest}
-      className={`h-[25px] text-[16px] font-medium ${rest.name === selectedButton.toString() ? "border- border-b border-solid border-text-tertiary" : "text-text-default"}`}
+      className={`h-[25px] text-[16px] font-medium ${rest.name === selectedButton?.toString() ? "border- border-b border-solid border-text-tertiary" : "text-text-default"}`}
       onClick={rest.onClick}
     >
       <p className="h-[19px]">{buttonName}</p>

--- a/app/[groupId]/tasks/_hooks/use-select-button.ts
+++ b/app/[groupId]/tasks/_hooks/use-select-button.ts
@@ -3,7 +3,9 @@ import React, { useState } from "react";
 import { TaskLists } from "../_components/todo/todo-contents";
 
 const useSelectButton = (taskLists: TaskLists) => {
-  const [selectedButton, setSelectedButton] = useState(taskLists[0]["id"]);
+  const [selectedButton, setSelectedButton] = useState<number | undefined>(
+    taskLists[0]?.id,
+  );
 
   const handleClickName = (
     e: React.MouseEvent<HTMLButtonElement, MouseEvent>,

--- a/app/[groupId]/tasks/_hooks/use-side-bar.ts
+++ b/app/[groupId]/tasks/_hooks/use-side-bar.ts
@@ -1,8 +1,8 @@
 import React, { useState } from "react";
 
-const useSideBar = (id: number) => {
+const useSideBar = (id: number | undefined) => {
   const [isSideBarOpen, setIsSiderOpen] = useState<boolean>(false);
-  const [todoId, setSideBarData] = useState<number>(id);
+  const [todoId, setSideBarData] = useState<number | undefined>(id);
 
   const handleClick = (e: React.MouseEvent<HTMLDivElement>) => {
     if (e.currentTarget.dataset.index) {

--- a/app/[groupId]/tasks/page.tsx
+++ b/app/[groupId]/tasks/page.tsx
@@ -13,8 +13,6 @@ import TodoContainer from "./_components/todo/todo-contianer";
 const page = async (context: any) => {
   const queryClient = new QueryClient();
   const { req, res, query, params } = context;
-  console.log(context);
-
   const result = await queryClient.fetchQuery({
     queryKey: ["getGroupInfo"],
     queryFn: () => getGroupInfo({ groupId: params.groupId }),
@@ -28,7 +26,8 @@ const page = async (context: any) => {
         result.taskLists[0].id,
         myConvertDateToYMD(new Date()),
       ],
-      queryFn: () => getTasks("101", result.taskLists[0].id, new Date()),
+      queryFn: () =>
+        getTasks(params.groupId, result.taskLists[0].id, new Date()),
     });
   }
 

--- a/app/[groupId]/tasks/page.tsx
+++ b/app/[groupId]/tasks/page.tsx
@@ -20,7 +20,7 @@ const page = async (context: any) => {
     queryFn: () => getGroupInfo({ groupId: params.groupId }),
   });
 
-  if (result.taskLists) {
+  if (result.taskLists[0]) {
     myConvertDateToYMD(new Date());
     await queryClient.prefetchQuery({
       queryKey: [

--- a/lib/apis/task/hooks/use-get-task.ts
+++ b/lib/apis/task/hooks/use-get-task.ts
@@ -3,8 +3,16 @@ import React from "react";
 
 import { getTask } from "..";
 
-const useGetTask = (groupId: string, taskListId: number, taskId: number) => {
+const useGetTask = (
+  groupId: string,
+  taskListId: number | undefined,
+  taskId: number | undefined,
+) => {
+  const isValid = () => {
+    return typeof taskListId === "number" && typeof taskId === "number";
+  };
   const { data, isPending } = useQuery({
+    enabled: isValid(),
     queryKey: ["getTask", taskId],
     queryFn: () => getTask(groupId, taskListId, taskId),
   });

--- a/lib/apis/task/hooks/use-get-tasks.ts
+++ b/lib/apis/task/hooks/use-get-tasks.ts
@@ -4,9 +4,13 @@ import React from "react";
 
 import { getTasks } from "..";
 
-const useGetTasks = (groupId: string, id: number, date: Date) => {
+const useGetTasks = (groupId: string, id: number | undefined, date: Date) => {
+  const isValid = () => {
+    return typeof id === "number" && typeof groupId === "number";
+  };
   myConvertDateToYMD(date);
   const { data, error, isPending } = useQuery({
+    enabled: isValid(),
     queryKey: ["getTasks", id, myConvertDateToYMD(date)],
     queryFn: () => getTasks(groupId, id, date),
   });

--- a/lib/apis/task/hooks/use-get-tasks.ts
+++ b/lib/apis/task/hooks/use-get-tasks.ts
@@ -6,8 +6,9 @@ import { getTasks } from "..";
 
 const useGetTasks = (groupId: string, id: number | undefined, date: Date) => {
   const isValid = () => {
-    return typeof id === "number" && typeof groupId === "number";
+    return typeof id === "number";
   };
+
   myConvertDateToYMD(date);
   const { data, error, isPending } = useQuery({
     enabled: isValid(),

--- a/lib/apis/task/index.ts
+++ b/lib/apis/task/index.ts
@@ -33,7 +33,7 @@ const postTask = async (groupId: number, taskListId: number, data: any) => {
 
 export const getTasks = async (
   groupId: string,
-  taskListId: number,
+  taskListId: number | undefined,
   date: Date,
 ): Promise<GetTasksResponse> => {
   const convertedDateToYMD = myConvertDateToYMD(date);
@@ -57,8 +57,8 @@ export const getTasks = async (
 
 export const getTask = async (
   groupId: string,
-  taskListId: number,
-  taskId: number,
+  taskListId: number | undefined,
+  taskId: number | undefined,
 ): Promise<GetTaskResponse> => {
   try {
     const response = await myFetch<GetTaskResponse>(


### PR DESCRIPTION
<!-- PR 제목은 커밋 메세지 컨벤션 형식으로 작성 -->

## 🏷️ 이슈 번호 <!-- 이슈 번호 입력 -->

- close #116 

## 🧱 작업 사항
서버사이드에서나 클라언트사이드에서 올바르지 않는 파라미터로 리액트쿼리에 접근하면 리액트쿼리가 api를 호출하지 않도록 방지했습니다.

## 📸 결과물
![image](https://github.com/user-attachments/assets/ea4b4da7-1990-47a2-b0e5-7453638512ed)

## 💬 공유 포인트 및 논의 사항
enable이 false이면  tanstak쿼리의 key값이 null되는것 같습니다