### PR TITLE
 feat: 자유게시판 상품 등록 모달 구현

### DIFF
--- a/app/(free-board)/_components/add-board-modal/_components/file-drag-down.tsx
+++ b/app/(free-board)/_components/add-board-modal/_components/file-drag-down.tsx
@@ -1,0 +1,95 @@
+import Button from "@/components/button/button";
+import Image from "next/image";
+import { Dispatch, SetStateAction, useState } from "react";
+import { useDropzone } from "react-dropzone";
+
+export interface FileDragDownProps {
+  file: File | null;
+  onSelect: (file: File) => void;
+}
+
+export default function FileDragDown({ file, onSelect }: FileDragDownProps) {
+  const [preview, setPreview] = useState<string | null>(() =>
+    file ? URL.createObjectURL(file) : null,
+  );
+  const { open, getRootProps, getInputProps } = useDropzone({
+    noClick: true,
+    noKeyboard: true,
+    accept: {
+      "image/*": [],
+    },
+    onDrop: (acceptedFiles) => {
+      onSelect(acceptedFiles[0]);
+      setPreview(URL.createObjectURL(acceptedFiles[0]));
+    },
+  });
+
+  return (
+    <div>
+      <section className="h-[60vh] w-full px-5 pt-5">
+        <div
+          {...getRootProps()}
+          className="flex h-full w-full flex-col items-center"
+        >
+          <section className="relative aspect-square w-full">
+            <input {...getInputProps()} />
+            {file && preview ? (
+              <div
+                className="relative inset-0 mx-auto h-full w-[60vh] rounded-xl bg-white"
+                key={file.name}
+              >
+                <Image
+                  fill
+                  src={preview}
+                  alt={file.name}
+                  onLoad={() => {
+                    URL.revokeObjectURL(preview);
+                  }}
+                  className="rounded-xl"
+                />
+              </div>
+            ) : (
+              <section className="relative inset-0 flex h-full w-full flex-col items-center justify-center rounded-xl border-2 border-dashed border-background-tertiary bg-white">
+                <svg
+                  aria-label="이미지나 동영상과 같은 미디어를 나타내는 아이콘"
+                  className=""
+                  fill="currentColor"
+                  height="77"
+                  role="img"
+                  viewBox="0 0 97.6 77.3"
+                  width="96"
+                >
+                  <title>이미지나 동영상과 같은 미디어를 나타내는 아이콘</title>
+                  <path
+                    d="M16.3 24h.3c2.8-.2 4.9-2.6 4.8-5.4-.2-2.8-2.6-4.9-5.4-4.8s-4.9 2.6-4.8 5.4c.1 2.7 2.4 4.8 5.1 4.8zm-2.4-7.2c.5-.6 1.3-1 2.1-1h.2c1.7 0 3.1 1.4 3.1 3.1 0 1.7-1.4 3.1-3.1 3.1-1.7 0-3.1-1.4-3.1-3.1 0-.8.3-1.5.8-2.1z"
+                    fill="currentColor"
+                  ></path>
+                  <path
+                    d="M84.7 18.4 58 16.9l-.2-3c-.3-5.7-5.2-10.1-11-9.8L12.9 6c-5.7.3-10.1 5.3-9.8 11L5 51v.8c.7 5.2 5.1 9.1 10.3 9.1h.6l21.7-1.2v.6c-.3 5.7 4 10.7 9.8 11l34 2h.6c5.5 0 10.1-4.3 10.4-9.8l2-34c.4-5.8-4-10.7-9.7-11.1zM7.2 10.8C8.7 9.1 10.8 8.1 13 8l34-1.9c4.6-.3 8.6 3.3 8.9 7.9l.2 2.8-5.3-.3c-5.7-.3-10.7 4-11 9.8l-.6 9.5-9.5 10.7c-.2.3-.6.4-1 .5-.4 0-.7-.1-1-.4l-7.8-7c-1.4-1.3-3.5-1.1-4.8.3L7 49 5.2 17c-.2-2.3.6-4.5 2-6.2zm8.7 48c-4.3.2-8.1-2.8-8.8-7.1l9.4-10.5c.2-.3.6-.4 1-.5.4 0 .7.1 1 .4l7.8 7c.7.6 1.6.9 2.5.9.9 0 1.7-.5 2.3-1.1l7.8-8.8-1.1 18.6-21.9 1.1zm76.5-29.5-2 34c-.3 4.6-4.3 8.2-8.9 7.9l-34-2c-4.6-.3-8.2-4.3-7.9-8.9l2-34c.3-4.4 3.9-7.9 8.4-7.9h.5l34 2c4.7.3 8.2 4.3 7.9 8.9z"
+                    fill="currentColor"
+                  ></path>
+                  <path
+                    d="M78.2 41.6 61.3 30.5c-2.1-1.4-4.9-.8-6.2 1.3-.4.7-.7 1.4-.7 2.2l-1.2 20.1c-.1 2.5 1.7 4.6 4.2 4.8h.3c.7 0 1.4-.2 2-.5l18-9c2.2-1.1 3.1-3.8 2-6-.4-.7-.9-1.3-1.5-1.8zm-1.4 6-18 9c-.4.2-.8.3-1.3.3-.4 0-.9-.2-1.2-.4-.7-.5-1.2-1.3-1.1-2.2l1.2-20.1c.1-.9.6-1.7 1.4-2.1.8-.4 1.7-.3 2.5.1L77 43.3c1.2.8 1.5 2.3.7 3.4-.2.4-.5.7-.9.9z"
+                    fill="currentColor"
+                  ></path>
+                </svg>
+                <p className="text-xl font-bold">
+                  사진과 동영상을 여기에 끌어다 놓으세요
+                </p>
+                <Button
+                  btnSize="x-small"
+                  btnStyle="solid"
+                  type="button"
+                  onClick={open}
+                  className="mt-5 px-4"
+                >
+                  컴퓨터에서 찾아보기
+                </Button>
+              </section>
+            )}
+          </section>
+        </div>
+      </section>
+    </div>
+  );
+}

--- a/app/(free-board)/_components/add-board-modal/_components/modal-cancel.tsx
+++ b/app/(free-board)/_components/add-board-modal/_components/modal-cancel.tsx
@@ -1,0 +1,37 @@
+import Modal from "@/components/modal/modal";
+import Alert from "@/public/icons/alert.svg";
+import { useCallback } from "react";
+
+interface ModalCancelProps {
+  close: () => void;
+  onCancel: () => void;
+}
+
+export default function ModalCancel({ close, onCancel }: ModalCancelProps) {
+  const handleClick = useCallback(() => {
+    onCancel();
+    close();
+  }, [close, onCancel]);
+  return (
+    <Modal close={close} closeOnFocusOut>
+      <header className="flex justify-center pb-4 pt-6">
+        <Alert width={24} height={24} />
+      </header>
+      <div className="mx-12 text-center md:mx-9">
+        <Modal.Title className="mb-4 text-slate-50 md:text-text-primary">
+          다른 사진을 선택하시겠습니까?
+        </Modal.Title>
+        <Modal.Description className="mb-6">
+          선택한 사진은 초기화됩니다.
+        </Modal.Description>
+        <Modal.TwoButtonSection
+          closeBtnStyle="outlined_secondary"
+          confirmBtnStyle="danger"
+          buttonDescription="취소하기"
+          onClick={handleClick}
+          close={close}
+        />
+      </div>
+    </Modal>
+  );
+}

--- a/app/(free-board)/_components/add-board-modal/index.tsx
+++ b/app/(free-board)/_components/add-board-modal/index.tsx
@@ -1,0 +1,158 @@
+import Button from "@/components/button/button";
+import { BasicInput } from "@/components/input-field/basic-input";
+import { BasicTextarea } from "@/components/input-field/textarea";
+import { useCustomOverlay } from "@/hooks/use-custom-overlay";
+import usePreventScroll from "@/hooks/use-prevent-scroll";
+import { yupResolver } from "@hookform/resolvers/yup";
+import { useState } from "react";
+import { FieldValues, SubmitHandler, useForm } from "react-hook-form";
+
+import FileDragDown from "./_components/file-drag-down";
+import ModalCancel from "./_components/modal-cancel";
+import { articleFormSchema } from "./schema";
+
+interface AddBoardModalProps {
+  close: () => void;
+}
+
+export interface FormType {
+  title: string;
+  content: string;
+  image: File;
+}
+
+export default function AddBoardModal({ close }: AddBoardModalProps) {
+  const [isNext, setIsNext] = useState(false);
+  const [file, setFile] = useState<File | null>(null);
+  const {
+    setValue,
+    register,
+    handleSubmit,
+    formState: { errors },
+  } = useForm({
+    mode: "onChange",
+    resolver: yupResolver(articleFormSchema),
+  });
+  const cancelOverlay = useCustomOverlay(({ close }) => (
+    <ModalCancel
+      close={close}
+      onCancel={() => {
+        setFile(null);
+      }}
+    />
+  ));
+
+  const handleNext = () => {
+    setIsNext(true);
+  };
+  const handlePrev = () => {
+    setIsNext(false);
+  };
+  const handleCancel = cancelOverlay.open;
+
+  //TODO : 서버로 데이터 전송
+  const handlePost: SubmitHandler<FormType> = (d) => {
+    console.log(d);
+    close();
+  };
+  const handleImage = (image: File) => {
+    setValue("image", image);
+    setFile(image);
+  };
+
+  usePreventScroll();
+
+  return (
+    <section className="relative">
+      {isNext ? (
+        <header className="flex justify-start gap-2">
+          <Button
+            btnSize="x-small"
+            btnStyle="solid"
+            onClick={handlePrev}
+            type="button"
+            className="w-14 xl:w-20"
+          >
+            이전
+          </Button>
+        </header>
+      ) : file ? (
+        <header className="flex items-center justify-between gap-2">
+          <svg
+            aria-label="돌아가기"
+            className="h-6 w-6 cursor-pointer"
+            fill="currentColor"
+            height="24"
+            role="img"
+            viewBox="0 0 24 24"
+            width="24"
+            onClick={handleCancel}
+          >
+            <title>돌아가기</title>
+            <line
+              fill="none"
+              stroke="rgb(16 185 129)"
+              strokeLinecap="round"
+              strokeLinejoin="round"
+              strokeWidth="2"
+              x1="2.909"
+              x2="22.001"
+              y1="12.004"
+              y2="12.004"
+            ></line>
+            <polyline
+              fill="none"
+              points="9.276 4.726 2.001 12.004 9.276 19.274"
+              stroke="rgb(16 185 129)"
+              strokeLinecap="round"
+              strokeLinejoin="round"
+              strokeWidth="2"
+            ></polyline>
+          </svg>
+          <Button
+            btnSize="x-small"
+            btnStyle="solid"
+            onClick={handleNext}
+            type="button"
+            className="w-14 xl:w-20"
+          >
+            다음
+          </Button>
+        </header>
+      ) : null}
+      <section>
+        {!isNext ? (
+          <FileDragDown file={file} onSelect={handleImage} />
+        ) : (
+          <form onSubmit={handleSubmit(handlePost)}>
+            <Button
+              type="submit"
+              btnSize="x-small"
+              btnStyle="solid"
+              className="absolute right-0 top-0 w-14 xl:w-20"
+            >
+              올리기
+            </Button>
+            <section className="mt-4 flex flex-col gap-4">
+              <BasicInput
+                register={register}
+                id="title"
+                label="제목"
+                error={errors.title?.message}
+              />
+              <BasicTextarea
+                register={register}
+                id="content"
+                label="내용"
+                className="resize-none"
+                rows={10}
+                cols={30}
+                error={errors.content?.message}
+              />
+            </section>
+          </form>
+        )}
+      </section>
+    </section>
+  );
+}

--- a/app/(free-board)/_components/add-board-modal/schema/index.ts
+++ b/app/(free-board)/_components/add-board-modal/schema/index.ts
@@ -1,0 +1,21 @@
+import { ObjectSchema, mixed, object, string } from "yup";
+
+import { FormType } from "..";
+
+function checkIfFilesAreTooBig(file: File): boolean {
+  let valid = true;
+  const size = file.size / 1024 / 1024;
+  if (size > 10) {
+    valid = false;
+  }
+  return valid;
+}
+
+export const articleFormSchema: ObjectSchema<FormType> = object().shape({
+  title: string().required("제목을 꼭 입력해주세요!"),
+  content: string().required("내용을 꼭 입력해주세요!"),
+  image: mixed<File>()
+    .nonNullable("이미지를 꼭 업로드해주세요.")
+    .required("이미지를 꼭 업로드해주세요.")
+    .test("fileSize", "파일 사이즈가 너무 큽니다", checkIfFilesAreTooBig),
+});

--- a/app/(free-board)/_components/add-board.tsx
+++ b/app/(free-board)/_components/add-board.tsx
@@ -4,24 +4,23 @@ import Button from "@/components/button/button";
 import Modal from "@/components/modal/modal";
 import { useCustomOverlay } from "@/hooks/use-custom-overlay";
 
+import AddBoardModal from "./add-board-modal";
+
 export default function AddBoard() {
   const overlay = useCustomOverlay(({ close }) => (
-    <Modal close={close} closeOnFocusOut>
-      글쓰기 모달
+    <Modal close={close} closeOnFocusOut={false} className="md:!w-[500px]">
+      <Modal.HeaderWithClose className="fixed right-7 top-7" />
+      <AddBoardModal close={close} />
     </Modal>
   ));
   return (
-    <section className="fixed bottom-0 left-0 right-0">
-      <div className="mx-4 flex justify-end md:mx-6 xl:mx-auto xl:max-w-[1200px]">
-        <Button
-          btnSize="x-small"
-          btnStyle="solid"
-          className="mb-16 w-[104px] xl:mb-11"
-          onClick={overlay.open}
-        >
-          + 글쓰기
-        </Button>
-      </div>
-    </section>
+    <Button
+      btnSize="x-small"
+      btnStyle="solid"
+      className="fixed bottom-11 right-4 w-[104px] md:right-6 xl:right-[calc(50vw-600px)]"
+      onClick={overlay.open}
+    >
+      + 글쓰기
+    </Button>
   );
 }

--- a/app/(free-board)/_components/card.tsx
+++ b/app/(free-board)/_components/card.tsx
@@ -44,7 +44,7 @@ function KebabButton({ onPatch, onDelete, ...props }: KebabButtonProps) {
     setIsOpen(false);
   }, [onDelete]);
   return (
-    <section className="group relative h-5 w-5 md:h-6 md:w-6" ref={ref}>
+    <section className="group relative h-6 w-6" ref={ref}>
       <button {...props} onClick={() => setIsOpen((prev) => !prev)}>
         <svg
           width="current"
@@ -72,20 +72,20 @@ function KebabButton({ onPatch, onDelete, ...props }: KebabButtonProps) {
         </svg>
       </button>
       {isOpen && (
-        <div className="absolute right-0 z-10 mt-1 flex w-[94px] flex-col rounded-xl bg-background-tertiary hover:cursor-pointer">
+        <div className="absolute right-0 z-10 flex w-[94px] flex-col rounded-xl bg-background-tertiary hover:cursor-pointer xl:w-[120px]">
           <div
-            className="h-10 w-[94px] border-b border-text-default first:rounded-t-xl last:rounded-b-xl last:border-b-0 hover:text-[#41ff30] hover:underline"
+            className="h-10 w-full border-b border-text-default first:rounded-t-xl last:rounded-b-xl last:border-b-0 hover:text-[#41ff30] hover:underline"
             onClick={handlePatch}
           >
-            <div className="flex h-full w-full items-center justify-center px-[14px] text-xs">
+            <div className="flex h-full w-full items-center justify-center px-[14px] text-xs xl:text-sm">
               수정하기
             </div>
           </div>
           <div
-            className="h-10 w-[94px] border-b border-text-default first:rounded-t-xl last:rounded-b-xl last:border-b-0 hover:text-[#41ff30] hover:underline"
+            className="h-10 w-full border-b border-text-default first:rounded-t-xl last:rounded-b-xl last:border-b-0 hover:text-[#41ff30] hover:underline"
             onClick={handleDelete}
           >
-            <div className="flex h-full w-full items-center justify-center px-[14px] text-xs">
+            <div className="flex h-full w-full items-center justify-center px-[14px] text-xs xl:text-sm">
               삭제하기
             </div>
           </div>

--- a/app/(free-board)/boards/_components/ordered-by-selector.tsx
+++ b/app/(free-board)/boards/_components/ordered-by-selector.tsx
@@ -34,7 +34,7 @@ export default function OrderedBySelector() {
   return (
     <Dropdown defaultSelected="최신순">
       <section className="text-xs md:text-sm">
-        <Dropdown.Button className="h-10 w-[94px] justify-between rounded-xl bg-background-tertiary px-[14px] md:h-11 md:w-[120px]">
+        <Dropdown.Button className="h-10 !w-[94px] justify-between rounded-xl bg-background-tertiary px-[14px] md:h-11 md:!w-[120px]">
           <ToggleClose
             width="24"
             height="24"

--- a/app/(free-board)/boards/page.tsx
+++ b/app/(free-board)/boards/page.tsx
@@ -5,8 +5,8 @@ import TagList from "./_components/tag-list";
 export default function Page() {
   return (
     <section className="mt-8">
-      <header className="mb-6 flex h-10 items-center justify-between gap-10 text-base font-medium text-text-primary md:h-11">
-        <h2 className="selection:bg-inherit">게시글</h2>
+      <header className="mb-6 flex h-10 items-center justify-between text-base font-medium text-text-primary md:h-11">
+        <h2 className="flex-1 selection:bg-inherit">게시글</h2>
         <OrderedBySelector />
       </header>
       <TagList />

--- a/components/input-field/textarea.tsx
+++ b/components/input-field/textarea.tsx
@@ -1,0 +1,66 @@
+import { TextareaHTMLAttributes } from "react";
+import { FieldValues, Path, UseFormRegister } from "react-hook-form";
+
+export interface BasicTextareaProps<TFormInput extends FieldValues>
+  extends TextareaHTMLAttributes<HTMLTextAreaElement> {
+  id: Path<TFormInput>;
+  register: UseFormRegister<TFormInput>;
+  label?: string;
+  error?: string;
+  isModal?: boolean;
+  className?: string;
+}
+
+/**
+ * @author 김서영 (modified by 이승현)
+ * 기본적으로 사용되는 textarea입니다.
+ * @param rest:  placeholder,type 등이 옵니다.
+ * @param id: 해당 input에 대한 id 입니다.(=name)
+ * @param label: 라벨이 사용되지 않는 경우가 있어 옵셔널을 주었습니다.
+ * @param error: 유효성 검사에 어긋나는 경우 나타나는 에러 메세지입니다.
+ * @param isModal: 모달에서 사용하는 경우 true로 지정하여 스타일을 다르게 줍니다.
+ * @example
+ * <BasicInput<ExampleInput>
+          register={register}
+          id="email"
+          placeholder="이메일을 입력해 주세요"
+          type="email"
+          label="이메일"
+          error={errors.email?.message}
+        />
+ **/
+export function BasicTextarea<TFormInput extends FieldValues>({
+  register,
+  id,
+  label,
+  error,
+  isModal,
+  className,
+  ...rest
+}: BasicTextareaProps<TFormInput>) {
+  return (
+    <>
+      <div className={`flex flex-col ${isModal ? "gap-2" : "gap-3"}`}>
+        {label && (
+          <label
+            htmlFor={id}
+            className="text-base font-semibold text-text-primary"
+          >
+            {label}
+          </label>
+        )}
+        <textarea
+          className={`w-full rounded-xl border border-border-primary border-opacity-10 bg-background-secondary px-4 py-[13.5px] text-base font-normal text-text-primary placeholder:text-sm placeholder:font-normal placeholder:text-text-default read-only:cursor-not-allowed read-only:bg-background-tertiary focus:border-2 focus:outline-none ${error ? "focus:border-status-danger" : "focus:border-interaction-focus"} ${className}`}
+          {...register(id)}
+          {...rest}
+          id={id}
+        />
+        {error && (
+          <p className="ml-[13.5px] text-sm font-medium text-status-danger">
+            {error}
+          </p>
+        )}
+      </div>
+    </>
+  );
+}

--- a/components/modal/modal.tsx
+++ b/components/modal/modal.tsx
@@ -31,6 +31,7 @@ interface ModalProps {
   closeOnFocusOut: boolean;
   close: () => void;
   children: React.ReactNode;
+  className?: string;
 }
 
 Modal.Title = Title;
@@ -84,6 +85,7 @@ export default function Modal({
   children,
   close,
   closeOnFocusOut,
+  className,
 }: ModalProps) {
   const modalRef = useClickOutside(() => {
     close();
@@ -97,7 +99,7 @@ export default function Modal({
             animate={{ opacity: 1, y: 0 }}
             initial={{ opacity: 0, y: 100 }}
             transition={{ duration: 0.1 }}
-            className={cn(modalVariants())}
+            className={cn(modalVariants({ className }))}
             ref={
               closeOnFocusOut
                 ? (modalRef as LegacyRef<HTMLDivElement> | undefined)

--- a/hooks/use-prevent-scroll.ts
+++ b/hooks/use-prevent-scroll.ts
@@ -1,0 +1,22 @@
+import { allowScroll, preventScroll } from "@/utils/scroll";
+import { useEffect } from "react";
+
+/**
+ * 스크롤 방지 후, 컴포넌트가 언마운트될 때 스크롤을 허용한다.
+ * 모달 같은 곳에서 스크롤을 방지할 때 사용하시면 됩니다.
+ * @author 이승현
+ * @example
+ * ```tsx
+ * // 모달 컴포넌트.tsx
+ *
+ * usePreventScroll();
+ * ```
+ */
+export default function usePreventScroll() {
+  useEffect(() => {
+    const prevScrollY = preventScroll();
+    return () => {
+      allowScroll(prevScrollY);
+    };
+  }, []);
+}

--- a/utils/scroll.ts
+++ b/utils/scroll.ts
@@ -1,0 +1,26 @@
+// utils/modal.ts
+
+/**
+ * 스크롤을 방지하고 현재 위치를 반환한다.
+ * @returns {number} 현재 스크롤 위치
+ */
+export const preventScroll = () => {
+  const currentScrollY = window.scrollY;
+  document.body.style.position = "fixed";
+  document.body.style.width = "100%";
+  document.body.style.top = `-${currentScrollY}px`; // 현재 스크롤 위치
+  document.body.style.overflowY = "hidden";
+  return currentScrollY;
+};
+
+/**
+ * 스크롤을 허용하고, 스크롤 방지 함수에서 반환된 위치로 이동한다.
+ * @param prevScrollY 스크롤 방지 함수에서 반환된 스크롤 위치
+ */
+export const allowScroll = (prevScrollY: number) => {
+  document.body.style.position = "";
+  document.body.style.width = "";
+  document.body.style.top = "";
+  document.body.style.overflowY = "";
+  window.scrollTo(0, prevScrollY);
+};


### PR DESCRIPTION
<!-- PR 제목은 커밋 메세지 컨벤션 형식으로 작성 -->

## 🏷️ 이슈 번호 #120 

- close #120 

## 🧱 작업 사항

- 자유게시판 관련 자잘한 에러들 수정했습니다.
- 자유 게시판 상품 등록 모달을 완성했습니다. (react-hook-form 연결, 관련 조건부 처리)
- 자유 게시판 상품 등록시 파일을 드래그해서 넣을 수 있습니다.
- 스크롤 방지하는 훅을 만들었습니다.
- 모달 컴포넌트에 className을 추가했습니다. 이제 모달 컴포넌트 자체의 스타일링을 따로 입힐 수 있습니다.

## 📸 결과물

![image](https://github.com/user-attachments/assets/bbc64def-6f6f-489b-9154-13e375e0849a)
![image](https://github.com/user-attachments/assets/f7d3c30e-3522-4f5c-ba59-ef6d69061d9c)
![image](https://github.com/user-attachments/assets/9c5adbfe-0496-4c02-8a8a-d6d1c1f63312)
![image](https://github.com/user-attachments/assets/65df5427-a9dc-4023-add8-6c7431fa74d8)


## 💬 공유 포인트 및 논의 사항
- 기능은 다 되는데 스타일이 조금 아쉬운거 같아요. 혹시나 괜찮은 아이디어 있으시면 말씀 부탁드립니다