### PR TITLE
refactor: 프로필 인풋 컴포넌트 리팩토링

### DIFF
--- a/app/mypage/_component/update-user-form.tsx
+++ b/app/mypage/_component/update-user-form.tsx
@@ -1,4 +1,10 @@
+"use client";
+
 import { BasicInput } from "@/components/input-field/basic-input";
+import { ProfileInput } from "@/components/profile-input/profile-input";
+import { updateUserSchema } from "@/schemas/user";
+import { yupResolver } from "@hookform/resolvers/yup";
+import { SubmitHandler, useForm } from "react-hook-form";
 
 interface UpdateUserFormProps {
   image: string | null;
@@ -8,8 +14,7 @@ interface UpdateUserFormProps {
 
 interface UpdateUserInputValue {
   nickname: string;
-  image: File | null;
-  email: string;
+  image?: File | string;
 }
 
 export default function UpdateUserForm({
@@ -17,5 +22,50 @@ export default function UpdateUserForm({
   nickname,
   email,
 }: UpdateUserFormProps) {
-  return <form></form>;
+  const {
+    register,
+    handleSubmit,
+    setValue,
+    resetField,
+    watch,
+    formState: { errors, isValid },
+  } = useForm<UpdateUserInputValue>({
+    mode: "onChange",
+    defaultValues: {
+      nickname,
+      image: image ?? undefined,
+    },
+    resolver: yupResolver(updateUserSchema),
+  });
+
+  const onSubmit: SubmitHandler<UpdateUserInputValue> = async (data) => {
+    console.log(data);
+  };
+
+  return (
+    <form onSubmit={handleSubmit(onSubmit)}>
+      <div>
+        {/* TODO - ProfileInput */}
+        <ProfileInput<UpdateUserInputValue>
+          id="image"
+          type="myProfile"
+          register={register}
+          setValue={setValue}
+          resetField={resetField}
+          error={errors.image?.message}
+          defaultValue={image ?? undefined}
+        />
+        <BasicInput<UpdateUserInputValue>
+          register={register}
+          id="nickname"
+          placeholder="닉네임을 입력해 주세요"
+          label="닉네임"
+          error={errors.nickname?.message}
+        />
+      </div>
+      <button type="submit" disabled={!isValid}>
+        제출
+      </button>
+    </form>
+  );
 }

--- a/app/mypage/_component/update-user-form.tsx
+++ b/app/mypage/_component/update-user-form.tsx
@@ -27,7 +27,6 @@ export default function UpdateUserForm({
     handleSubmit,
     setValue,
     resetField,
-    watch,
     formState: { errors, isValid },
   } = useForm<UpdateUserInputValue>({
     mode: "onChange",
@@ -39,6 +38,7 @@ export default function UpdateUserForm({
   });
 
   const onSubmit: SubmitHandler<UpdateUserInputValue> = async (data) => {
+    console.log(">>.");
     console.log(data);
   };
 
@@ -49,7 +49,6 @@ export default function UpdateUserForm({
         <ProfileInput<UpdateUserInputValue>
           id="image"
           type="myProfile"
-          register={register}
           setValue={setValue}
           resetField={resetField}
           error={errors.image?.message}
@@ -63,9 +62,7 @@ export default function UpdateUserForm({
           error={errors.nickname?.message}
         />
       </div>
-      <button type="submit" disabled={!isValid}>
-        제출
-      </button>
+      <button>제출</button>
     </form>
   );
 }

--- a/app/mypage/_component/update-user-form.tsx
+++ b/app/mypage/_component/update-user-form.tsx
@@ -1,0 +1,21 @@
+import { BasicInput } from "@/components/input-field/basic-input";
+
+interface UpdateUserFormProps {
+  image: string | null;
+  nickname: string;
+  email: string;
+}
+
+interface UpdateUserInputValue {
+  nickname: string;
+  image: File | null;
+  email: string;
+}
+
+export default function UpdateUserForm({
+  image,
+  nickname,
+  email,
+}: UpdateUserFormProps) {
+  return <form></form>;
+}

--- a/app/mypage/_component/update-user-form.tsx
+++ b/app/mypage/_component/update-user-form.tsx
@@ -26,7 +26,6 @@ export default function UpdateUserForm({
     register,
     handleSubmit,
     setValue,
-    resetField,
     formState: { errors, isValid },
   } = useForm<UpdateUserInputValue>({
     mode: "onChange",
@@ -38,19 +37,16 @@ export default function UpdateUserForm({
   });
 
   const onSubmit: SubmitHandler<UpdateUserInputValue> = async (data) => {
-    console.log(">>.");
     console.log(data);
   };
 
   return (
     <form onSubmit={handleSubmit(onSubmit)}>
       <div>
-        {/* TODO - ProfileInput */}
         <ProfileInput<UpdateUserInputValue>
           id="image"
           type="myProfile"
           setValue={setValue}
-          resetField={resetField}
           error={errors.image?.message}
           defaultValue={image ?? undefined}
         />

--- a/app/mypage/layout.tsx
+++ b/app/mypage/layout.tsx
@@ -8,7 +8,7 @@ export default function Layout({
   children: React.ReactNode;
 }>) {
   return (
-    <div className="mx-auto w-full max-w-[343px] md:max-w-[696px] xl:max-w-[792px]">
+    <div className="mx-auto w-full px-4 pt-6 md:px-6 xl:max-w-[792px] xl:pt-[40px]">
       {children}
     </div>
   );

--- a/app/mypage/page.tsx
+++ b/app/mypage/page.tsx
@@ -1,12 +1,14 @@
-"use client";
+import { getUser } from "../action";
+import UpdateUserForm from "./_component/update-user-form";
 
-import { useCustomOverlay } from "@/hooks/use-custom-overlay";
-
-import { ModalWarning } from "./_component/modal-warning";
-
-export default function Page() {
-  const overlay1 = useCustomOverlay(({ close }) => (
-    <ModalWarning close={close} handleConfirm={() => console.log("ㅎㅇ")} />
-  ));
-  return <button onClick={overlay1.open}>클릭</button>;
+export default async function Page() {
+  const { image, nickname, email } = await getUser();
+  return (
+    <>
+      <h1 className="text-lg font-bold text-text-primary md:text-xl">
+        계정 설정
+      </h1>
+      <UpdateUserForm image={image} nickname={nickname} email={email} />
+    </>
+  );
 }

--- a/app/mypage/page.tsx
+++ b/app/mypage/page.tsx
@@ -1,4 +1,5 @@
-import { getUser } from "../action";
+import { getUser } from "@/lib/apis/user";
+
 import UpdateUserForm from "./_component/update-user-form";
 
 export default async function Page() {

--- a/components/header/popover-trigger.tsx
+++ b/components/header/popover-trigger.tsx
@@ -28,6 +28,7 @@ export default function PopoverTrigger({ nickname }: PopoverTriggerProps) {
           },
           {
             text: LOGGED_IN_USER_CONTENT[1],
+            onClick: () => (window.location.href = "/mypage"),
           },
           {
             text: LOGGED_IN_USER_CONTENT[2],

--- a/components/header/popover-trigger.tsx
+++ b/components/header/popover-trigger.tsx
@@ -3,6 +3,7 @@
 import { LOGGED_IN_USER_CONTENT } from "@/constants/popover-content";
 import { useCustomOverlay } from "@/hooks/use-custom-overlay";
 import UserIcon from "@/public/icons/user.svg";
+import { useRouter } from "next/navigation";
 
 import Popover from "../popover/popover";
 import ModalLogout from "./components/modal-logout";
@@ -12,6 +13,7 @@ interface PopoverTriggerProps {
 }
 
 export default function PopoverTrigger({ nickname }: PopoverTriggerProps) {
+  const router = useRouter();
   const modalLogoutOverlay = useCustomOverlay(({ close }) => (
     <ModalLogout close={close} />
   ));
@@ -28,7 +30,7 @@ export default function PopoverTrigger({ nickname }: PopoverTriggerProps) {
           },
           {
             text: LOGGED_IN_USER_CONTENT[1],
-            onClick: () => (window.location.href = "/mypage"),
+            onClick: () => router.push("/mypage"),
           },
           {
             text: LOGGED_IN_USER_CONTENT[2],

--- a/components/input-field/basic-input.tsx
+++ b/components/input-field/basic-input.tsx
@@ -50,7 +50,7 @@ export function BasicInput<TFormInput extends FieldValues>({
           </label>
         )}
         <input
-          className={`w-full rounded-xl border border-border-primary border-opacity-10 bg-background-secondary px-4 py-[13.5px] text-base font-normal text-text-primary placeholder:text-sm placeholder:font-normal placeholder:text-text-default read-only:cursor-not-allowed read-only:bg-background-tertiary focus:border-2 focus:outline-none ${error ? "focus:border-status-danger" : "focus:border-interaction-focus"} ${className}`}
+          className={`w-full rounded-xl border border-border-primary border-opacity-10 bg-background-secondary px-4 py-[13.5px] text-base font-normal text-text-primary placeholder:text-sm placeholder:font-normal placeholder:text-text-default focus:border-2 focus:outline-none disabled:cursor-not-allowed disabled:bg-background-tertiary ${error ? "focus:border-status-danger" : "focus:border-interaction-focus"} ${className}`}
           {...register(id)}
           {...rest}
           id={id}

--- a/components/input-field/password-input.tsx
+++ b/components/input-field/password-input.tsx
@@ -16,7 +16,7 @@ interface PasswordInputProps<TFormInput extends FieldValues>
  * @author 김서영
  * 비밀번호 토글 기능이 있는 input입니다.
  * BasicInput 컴포넌트에서 눈 버튼과 토글 기능이 추가된 컴포넌트입니다.
- * @param rest: placeholder, type 등이 옵니다. readOnly 속성이 있는 경우 변경하기 버튼이 보여집니다.
+ * @param rest: placeholder, type 등이 옵니다. disabled  속성이 있는 경우 변경하기 버튼이 보여집니다.
  * @param id: 해당 input에 대한 id 입니다.(=name)
  * @param label: 라벨이 사용되지 않는 경우가 있어 옵셔널을 주었습니다.
  * @param error: 유효성 검사에 어긋나는 경우 나타나는 에러 메세지입니다.
@@ -39,7 +39,7 @@ export default function PasswordInput<TFormInput extends FieldValues>({
   const [showPassword, setShowPassword] = useState(false);
 
   // NOTE - readOnly 속성이 rest에 포함되어 있는지 확인(변경하기 버튼이 있는 경우)
-  const isReadOnly = rest.readOnly === true;
+  const isDisabled = rest.disabled === true;
 
   const handleToggleShowPassword = () => {
     setShowPassword((prev) => !prev);
@@ -56,7 +56,7 @@ export default function PasswordInput<TFormInput extends FieldValues>({
         {...rest}
       />
       {/* TODO - 클릭 시 모달 열기 */}
-      {isReadOnly ? (
+      {isDisabled ? (
         <Button
           btnSize="x-small"
           btnStyle="solid"

--- a/components/profile-input/profile-input.tsx
+++ b/components/profile-input/profile-input.tsx
@@ -1,7 +1,6 @@
 import TeamProfile from "@/public/icons/img.svg";
 import MyProfile from "@/public/icons/my-profile.svg";
 import X from "@/public/icons/x.svg";
-import { error } from "console";
 import Image from "next/image";
 import { ChangeEvent, InputHTMLAttributes, MouseEvent, useState } from "react";
 import React from "react";
@@ -9,7 +8,6 @@ import {
   FieldValues,
   Path,
   PathValue,
-  UseFormRegister,
   UseFormResetField,
   UseFormSetValue,
 } from "react-hook-form";
@@ -18,7 +16,6 @@ export interface ProfileInputProps<TFormInput extends FieldValues>
   extends InputHTMLAttributes<HTMLInputElement> {
   id: Path<TFormInput>;
   setValue: UseFormSetValue<TFormInput>;
-  resetField: UseFormResetField<TFormInput>;
   error?: string;
   defaultValue?: string;
   type: "teamProfile" | "myProfile";
@@ -35,7 +32,6 @@ export function ProfileInput<TFormInput extends FieldValues>({
   type,
   setValue,
   defaultValue,
-  resetField,
   error,
   ...rest
 }: ProfileInputProps<TFormInput>) {
@@ -61,6 +57,7 @@ export function ProfileInput<TFormInput extends FieldValues>({
   const handleClearImage = (e: MouseEvent<HTMLButtonElement>) => {
     setValue(id, "" as PathValue<TFormInput, Path<TFormInput>>);
     setPreviewImage(null);
+    // NOTE - 이벤트 버블링으로 인해 input까지 같이 열려 추가
     e.preventDefault();
     e.stopPropagation();
   };
@@ -97,6 +94,7 @@ export function ProfileInput<TFormInput extends FieldValues>({
           className="hidden"
           accept=".jpg, jpeg, .png"
           onChange={handleChangeFile}
+          {...rest}
         />
       </div>
     </>

--- a/components/profile-input/profile-input.tsx
+++ b/components/profile-input/profile-input.tsx
@@ -97,6 +97,11 @@ export function ProfileInput<TFormInput extends FieldValues>({
           {...rest}
         />
       </div>
+      {error && (
+        <p className="ml-[13.5px] text-sm font-medium text-status-danger">
+          {error}
+        </p>
+      )}
     </>
   );
 }

--- a/components/profile-input/profile-input.tsx
+++ b/components/profile-input/profile-input.tsx
@@ -1,86 +1,108 @@
 import TeamProfile from "@/public/icons/img.svg";
 import MyProfile from "@/public/icons/my-profile.svg";
 import X from "@/public/icons/x.svg";
+import { error } from "console";
 import Image from "next/image";
-import { ChangeEvent, useState } from "react";
+import { ChangeEvent, InputHTMLAttributes, MouseEvent, useState } from "react";
 import React from "react";
+import {
+  FieldValues,
+  Path,
+  PathValue,
+  UseFormRegister,
+  UseFormResetField,
+  UseFormSetValue,
+} from "react-hook-form";
 
-interface profileInputProps {
-  previewImage: string;
-  image: string;
+export interface ProfileInputProps<TFormInput extends FieldValues>
+  extends InputHTMLAttributes<HTMLInputElement> {
+  id: Path<TFormInput>;
+  register: UseFormRegister<TFormInput>;
+  setValue: UseFormSetValue<TFormInput>;
+  resetField: UseFormResetField<TFormInput>;
+  error?: string;
+  defaultValue?: string;
   type: "teamProfile" | "myProfile";
-  onChange: (e: ChangeEvent<HTMLInputElement>) => void;
-  onClick: () => void;
 }
 
 /**
- * @author : 이동규
+ * @author : 김서영
  * @typedef {Object} ProfileInputProps
- * @param {string} image - 서버에서 받아온 유저 이미지 URL
- * @param {string} preview - 미리보기 이미지 URL
+
  **/
 
-const ProfileInput = ({
-  previewImage,
-  image,
+export function ProfileInput<TFormInput extends FieldValues>({
+  register,
+  id,
   type,
-  onChange,
-  onClick,
-}: profileInputProps) => {
-  const [isImgError, setIsImgError] = useState<boolean>(false);
-  const handleError = () => {
-    setIsImgError(true);
+  setValue,
+  defaultValue,
+  resetField,
+  error,
+  ...rest
+}: ProfileInputProps<TFormInput>) {
+  const [previewImage, setPreviewImage] = useState<string | null>(
+    defaultValue || null,
+  );
+
+  const DefaultImage = type === "teamProfile" ? TeamProfile : MyProfile;
+
+  // NOTE - 파일 선택 시 프리뷰 설정 및 input 값 설정
+  const handleChangeFile = (e: ChangeEvent<HTMLInputElement>) => {
+    if (e.target.files) {
+      const file = e.target.files[0];
+      if (file) {
+        const preview = URL.createObjectURL(e.target.files[0]);
+        setValue(id, file as any);
+        setPreviewImage(preview);
+      }
+    }
   };
-  const errorImage = isImgError && !previewImage;
+
+  // NOTE - x 버튼 클릭 시 프리뷰 초기화 및 input 초기화
+  const handleClearImage = (e: MouseEvent<HTMLButtonElement>) => {
+    setValue(id, null as PathValue<TFormInput, Path<TFormInput>>);
+    setPreviewImage(null);
+    e.preventDefault();
+    e.stopPropagation();
+  };
 
   return (
-    <div className="h-16 w-16">
-      <label htmlFor="profileInput" className="relative cursor-pointer">
-        {type === "teamProfile" &&
-          (errorImage ? (
-            <TeamProfile width={64} height={64} />
+    <>
+      <div className="h-16 w-16">
+        <label htmlFor={id} className="relative cursor-pointer">
+          {previewImage ? (
+            <div className="relative size-[64px] overflow-hidden rounded-full">
+              <Image
+                fill
+                src={previewImage}
+                alt={type === "teamProfile" ? "팀 이미지" : "내 이미지"}
+              />
+            </div>
           ) : (
-            <Image
-              width={64}
-              height={64}
-              className="rounded-full"
-              src={image}
-              onError={handleError}
-              alt="팀이미지"
-            />
-          ))}
+            <DefaultImage width={64} height={64} />
+          )}
+          {previewImage && (
+            <button
+              type="button"
+              className="h-30 w-30 absolute left-12 top-1 rounded-full border-2 border-background-primary bg-background-tertiary"
+              onClick={handleClearImage}
+            >
+              <X width={18} height={18} />
+            </button>
+          )}
+        </label>
 
-        {type === "myProfile" &&
-          (errorImage ? (
-            <MyProfile width={64} height={64} />
-          ) : (
-            <Image
-              width={64}
-              height={64}
-              className="rounded-full"
-              src={previewImage ? previewImage : image}
-              onError={handleError}
-              alt="나의이미지"
-            />
-          ))}
-        {previewImage && (
-          <button
-            className="h-30 w-30 absolute left-12 top-1 rounded-full border-2 border-background-primary bg-background-tertiary"
-            onClick={onClick}
-          >
-            <X width={18} height={18} />
-          </button>
-        )}
-      </label>
-
-      <input
-        id="profileInput"
-        type="file"
-        accept=".jpg, jpeg, .png"
-        className="hidden"
-        onChange={onChange}
-      />
-    </div>
+        <input
+          id={id}
+          type="file"
+          className="hidden"
+          accept=".jpg, jpeg, .png"
+          onChange={handleChangeFile}
+        />
+      </div>
+    </>
   );
-};
+}
+
 export default ProfileInput;

--- a/components/profile-input/profile-input.tsx
+++ b/components/profile-input/profile-input.tsx
@@ -17,7 +17,6 @@ import {
 export interface ProfileInputProps<TFormInput extends FieldValues>
   extends InputHTMLAttributes<HTMLInputElement> {
   id: Path<TFormInput>;
-  register: UseFormRegister<TFormInput>;
   setValue: UseFormSetValue<TFormInput>;
   resetField: UseFormResetField<TFormInput>;
   error?: string;
@@ -32,7 +31,6 @@ export interface ProfileInputProps<TFormInput extends FieldValues>
  **/
 
 export function ProfileInput<TFormInput extends FieldValues>({
-  register,
   id,
   type,
   setValue,
@@ -53,7 +51,7 @@ export function ProfileInput<TFormInput extends FieldValues>({
       const file = e.target.files[0];
       if (file) {
         const preview = URL.createObjectURL(e.target.files[0]);
-        setValue(id, file as any);
+        setValue(id, file as PathValue<TFormInput, Path<TFormInput>>);
         setPreviewImage(preview);
       }
     }
@@ -61,7 +59,7 @@ export function ProfileInput<TFormInput extends FieldValues>({
 
   // NOTE - x 버튼 클릭 시 프리뷰 초기화 및 input 초기화
   const handleClearImage = (e: MouseEvent<HTMLButtonElement>) => {
-    setValue(id, null as PathValue<TFormInput, Path<TFormInput>>);
+    setValue(id, "" as PathValue<TFormInput, Path<TFormInput>>);
     setPreviewImage(null);
     e.preventDefault();
     e.stopPropagation();

--- a/lib/apis/user/index.ts
+++ b/lib/apis/user/index.ts
@@ -1,6 +1,5 @@
 import { SendEmailInputValue } from "@/app/(auth)/reset-password/_components/modal-send-email";
 import { getCookie } from "cookies-next";
-import { cookies } from "next/headers";
 
 import { myFetch } from "../myFetch";
 import {
@@ -12,7 +11,6 @@ import {
 } from "../type";
 
 export async function getUser(): Promise<GetTeamIdUserResponse> {
-  "use server";
   try {
     const response = await myFetch<GetTeamIdUserResponse>(
       `${process.env.NEXT_PUBLIC_KKOM_KKOM_URL}/user`,

--- a/lib/apis/user/index.ts
+++ b/lib/apis/user/index.ts
@@ -12,6 +12,7 @@ import {
 } from "../type";
 
 export async function getUser(): Promise<GetTeamIdUserResponse> {
+  "use server";
   try {
     const response = await myFetch<GetTeamIdUserResponse>(
       `${process.env.NEXT_PUBLIC_KKOM_KKOM_URL}/user`,

--- a/schemas/user.ts
+++ b/schemas/user.ts
@@ -1,14 +1,20 @@
 import * as yup from "yup";
 
-export const updateUserSchemas = yup.object().shape({
+export const updateUserSchema = yup.object().shape({
   nickname: yup
     .string()
     .max(30, "닉네임은 최대 30자까지 가능합니다.")
     .required("닉네임을 입력해 주세요."),
   image: yup
-    .mixed<File>()
-    .test("fileType", "JPG, JPEG, PNG 파일만 가능합니다.", (value) => {
+    .mixed<File | string>()
+    .test("fileOrString", "JPG, JPEG, PNG 파일만 가능합니다.", (value) => {
+      if (typeof value === "string") {
+        // NOTE - 문자열인 경우 유효성 검사 통과 (기본 이미지 URL 등)
+        return true;
+      }
+
       if (!value) return true; // NOTE - 파일이 선택되지 않았을 때는 유효성 검사 통과
+
       const fileType = value.type;
       return ["image/jpeg", "image/png", "image/jpg"].includes(fileType);
     }),

--- a/schemas/user.ts
+++ b/schemas/user.ts
@@ -5,5 +5,11 @@ export const updateUserSchemas = yup.object().shape({
     .string()
     .max(30, "닉네임은 최대 30자까지 가능합니다.")
     .required("닉네임을 입력해 주세요."),
-  email: yup.string().email("이메일 형식으로 작성해 주세요"),
+  image: yup
+    .mixed<File>()
+    .test("fileType", "JPG, JPEG, PNG 파일만 가능합니다.", (value) => {
+      if (!value) return true; // NOTE - 파일이 선택되지 않았을 때는 유효성 검사 통과
+      const fileType = value.type;
+      return ["image/jpeg", "image/png", "image/jpg"].includes(fileType);
+    }),
 });

--- a/schemas/user.ts
+++ b/schemas/user.ts
@@ -1,0 +1,9 @@
+import * as yup from "yup";
+
+export const updateUserSchemas = yup.object().shape({
+  nickname: yup
+    .string()
+    .max(30, "닉네임은 최대 30자까지 가능합니다.")
+    .required("닉네임을 입력해 주세요."),
+  email: yup.string().email("이메일 형식으로 작성해 주세요"),
+});


### PR DESCRIPTION
## 🏷️ 이슈 번호 #110 

- close #110

## 🧱 작업 사항

- 기본 이미지가 있는 경우 기본 input값으로 설정 및 프리뷰에 설정
- x 버튼 누를 경우 input 값 초기화 
- 파일 선택 후 input 값 설정 (File) 
- 파일 객체에 따로 접근해야 돼서 그런지 register로 안 돼서 setValue로 적용해주었습니다. 
- x 버튼 누른 후 이벤트 버블링으로 인해 input까지 같이 열리는 문제를 해결했습니다. 

## 📸 결과물
사용자 프로필  있는 경우 
![image](https://github.com/user-attachments/assets/1dcd6e46-c3d6-4f44-a861-0482f7cc88af)
파일 변경한 경우
![image](https://github.com/user-attachments/assets/8fc2f9dd-291e-4695-bb05-1681f97a2609)
x 누른 경우
![image](https://github.com/user-attachments/assets/2f4012e8-b0a0-4da7-b287-66eb2802691f)
사용자 프로필 없는 경우
![image](https://github.com/user-attachments/assets/0455cdcb-c745-406a-89d9-ef23fe889391)



## 💬 공유 포인트 및 논의 사항
- input 태그에 accept를 적용해 줘도 사용자가 모든 파일을 선택하는 경우 다른 확장자도 첨부할 수 있어서 yup에서 중복으로 유효성 검사해줘야 하는 거 같습니다 !! 
- 다른 인풋처럼 잘못된 확장자를 첨부할 경우 에러메세지가 뜨면 좋겠는데 제출하는 버튼을 눌러야 에러메세지까 뜨더라구요 .. 이건 방법을 찾아보겠습니당 
