### PR TITLE
chore: 카카오 계정 이미지 도메인 추가

### DIFF
--- a/next.config.mjs
+++ b/next.config.mjs
@@ -4,6 +4,7 @@ const nextConfig = {
     domains: [
       "sprint-fe-project.s3.ap-northeast-2.amazonaws.com",
       "example.com",
+      "t1.kakaocdn.net",
     ],
   },
   webpack: (config) => {


### PR DESCRIPTION
<!-- PR 제목은 커밋 메세지 컨벤션 형식으로 작성 -->

## 🏷️ 이슈 번호 #138 

- close #138

## 🧱 작업 사항
카카오로 가입한 계정의 프로필 이미지를 불러오지 못해 발생하는 오류 해결을 위해 도메인을 추가하였습니다.

## 📸 결과물

## 💬 공유 포인트 및 논의 사항
