### PR TITLE
feat: 팀 참여하기 페이지 구현

### DIFF
--- a/app/(team-setting)/participate-team/_components/participate-team-form.tsx
+++ b/app/(team-setting)/participate-team/_components/participate-team-form.tsx
@@ -20,21 +20,18 @@ const ParticipateTeamForm = ({ email }: ParticipateTeamFormProps) => {
 
   const handleButtonClick = async () => {
     try {
-      const response = await postGroupInvitation({
+      await postGroupInvitation({
         userEmail: email,
         token: teamLink,
       });
-
-      if (response.message) {
-        showToast("error", response.message);
-      } else {
-        showToast("success", "팀 참여에 성공했습니다.");
-        router.push("/");
-      }
+      showToast("success", "팀 참여에 성공하였습니다.");
+      router.push("/");
+      router.refresh();
     } catch (error) {
-      showToast("error", "팀 참여에 실패했습니다.");
-
-      console.error(error);
+      showToast(
+        "error",
+        error instanceof Error ? error.message : "팀 참여에 실패하였습니다.",
+      );
     }
   };
 

--- a/app/(team-setting)/participate-team/_components/participate-team-form.tsx
+++ b/app/(team-setting)/participate-team/_components/participate-team-form.tsx
@@ -1,29 +1,39 @@
 "use client";
 
 import Button from "@/components/button/button";
+import { BasicInput } from "@/components/input-field/basic-input";
 import { postGroupInvitation } from "@/lib/apis/group";
 import { showToast } from "@/lib/show-toast";
 import { useRouter, useSearchParams } from "next/navigation";
-import { ChangeEvent, useState } from "react";
+import { useForm } from "react-hook-form";
 
 interface ParticipateTeamFormProps {
   email: string;
+}
+
+interface TeamLinkFormValues {
+  token: string;
 }
 
 const ParticipateTeamForm = ({ email }: ParticipateTeamFormProps) => {
   const router = useRouter();
   const searchParams = useSearchParams();
 
-  const [tokenInput, setTokenInput] = useState(searchParams.get("token") || "");
-  const handleInputChange = (e: ChangeEvent<HTMLInputElement>) => {
-    setTokenInput(e.target.value);
-  };
+  const {
+    register,
+    handleSubmit,
+    formState: { errors },
+  } = useForm<TeamLinkFormValues>({
+    defaultValues: {
+      token: searchParams.get("token") || "",
+    },
+  });
 
-  const handleButtonClick = async () => {
+  const onSubmit = async (data: TeamLinkFormValues) => {
     try {
       await postGroupInvitation({
         userEmail: email,
-        token: tokenInput,
+        token: data.token,
       });
       showToast("success", "팀 참여에 성공하였습니다.");
       router.push("/");
@@ -37,23 +47,18 @@ const ParticipateTeamForm = ({ email }: ParticipateTeamFormProps) => {
   };
 
   return (
-    <>
+    <form onSubmit={handleSubmit(onSubmit)} className="w-full">
       <div className="flex w-full flex-col gap-[40px]">
         <div className="flex flex-col gap-[12px]">
-          <p className="text-[16px] font-[500]">팀 링크</p>
-          <input
-            className="w-full rounded-xl border border-border-primary border-opacity-10 bg-background-secondary px-4 py-[13.5px] text-base font-normal placeholder:text-sm placeholder:font-normal placeholder:text-text-default focus:border-2 focus:outline-none"
-            value={tokenInput}
-            onChange={handleInputChange}
+          <BasicInput<TeamLinkFormValues>
+            id="token"
+            register={register}
+            label="팀 링크"
+            placeholder="팀 링크를 입력해 주세요."
           />
         </div>
         <div className="flex flex-col gap-[10px]">
-          <Button
-            btnSize="large"
-            btnStyle="solid"
-            disabled={!tokenInput.trim()}
-            onClick={handleButtonClick}
-          >
+          <Button btnSize="large" btnStyle="solid">
             참여하기
           </Button>
           <p className="text-center text-[16px] font-[400]">
@@ -61,7 +66,7 @@ const ParticipateTeamForm = ({ email }: ParticipateTeamFormProps) => {
           </p>
         </div>
       </div>
-    </>
+    </form>
   );
 };
 

--- a/app/(team-setting)/participate-team/_components/participate-team-form.tsx
+++ b/app/(team-setting)/participate-team/_components/participate-team-form.tsx
@@ -1,13 +1,41 @@
 "use client";
 
 import Button from "@/components/button/button";
+import { postGroupInvitation } from "@/lib/apis/group";
+import { showToast } from "@/lib/show-toast";
+import { useRouter } from "next/navigation";
 import { ChangeEvent, useState } from "react";
 
-const ParticipateTeamForm = () => {
+interface ParticipateTeamFormProps {
+  email: string;
+}
+
+const ParticipateTeamForm = ({ email }: ParticipateTeamFormProps) => {
+  const router = useRouter();
   const [teamLink, setTeamLink] = useState("");
 
   const handleInputChange = (e: ChangeEvent<HTMLInputElement>) => {
     setTeamLink(e.target.value);
+  };
+
+  const handleButtonClick = async () => {
+    try {
+      const response = await postGroupInvitation({
+        userEmail: email,
+        token: teamLink,
+      });
+
+      if (response.message) {
+        showToast("error", response.message);
+      } else {
+        showToast("success", "팀 참여에 성공했습니다.");
+        router.push("/");
+      }
+    } catch (error) {
+      showToast("error", "팀 참여에 실패했습니다.");
+
+      console.error(error);
+    }
   };
 
   return (
@@ -22,7 +50,12 @@ const ParticipateTeamForm = () => {
         />
       </div>
       <div className="flex flex-col gap-[10px]">
-        <Button btnSize="large" btnStyle="solid" disabled={!teamLink.trim()}>
+        <Button
+          btnSize="large"
+          btnStyle="solid"
+          disabled={!teamLink.trim()}
+          onClick={handleButtonClick}
+        >
           참여하기
         </Button>
         <p className="text-center text-[16px] font-[400]">

--- a/app/(team-setting)/participate-team/_components/participate-team-form.tsx
+++ b/app/(team-setting)/participate-team/_components/participate-team-form.tsx
@@ -1,0 +1,36 @@
+"use client";
+
+import Button from "@/components/button/button";
+import { ChangeEvent, useState } from "react";
+
+const ParticipateTeamForm = () => {
+  const [teamLink, setTeamLink] = useState("");
+
+  const handleInputChange = (e: ChangeEvent<HTMLInputElement>) => {
+    setTeamLink(e.target.value);
+  };
+
+  return (
+    <div className="flex w-full flex-col gap-[40px]">
+      <div className="flex flex-col gap-[12px]">
+        <p className="text-[16px] font-[500]">팀 링크</p>
+        <input
+          className="w-full rounded-xl border border-border-primary border-opacity-10 bg-background-secondary px-4 py-[13.5px] text-base font-normal placeholder:text-sm placeholder:font-normal placeholder:text-text-default focus:border-2 focus:outline-none"
+          placeholder="팀 링크를 입력해주세요."
+          value={teamLink}
+          onChange={handleInputChange}
+        />
+      </div>
+      <div className="flex flex-col gap-[10px]">
+        <Button btnSize="large" btnStyle="solid" disabled={!teamLink.trim()}>
+          참여하기
+        </Button>
+        <p className="text-center text-[16px] font-[400]">
+          공유받은 팀 링크를 입력해 참여할 수 있어요.
+        </p>
+      </div>
+    </div>
+  );
+};
+
+export default ParticipateTeamForm;

--- a/app/(team-setting)/participate-team/_components/participate-team-form.tsx
+++ b/app/(team-setting)/participate-team/_components/participate-team-form.tsx
@@ -3,7 +3,7 @@
 import Button from "@/components/button/button";
 import { postGroupInvitation } from "@/lib/apis/group";
 import { showToast } from "@/lib/show-toast";
-import { useRouter } from "next/navigation";
+import { useRouter, useSearchParams } from "next/navigation";
 import { ChangeEvent, useState } from "react";
 
 interface ParticipateTeamFormProps {
@@ -12,17 +12,18 @@ interface ParticipateTeamFormProps {
 
 const ParticipateTeamForm = ({ email }: ParticipateTeamFormProps) => {
   const router = useRouter();
-  const [teamLink, setTeamLink] = useState("");
+  const searchParams = useSearchParams();
 
+  const [tokenInput, setTokenInput] = useState(searchParams.get("token") || "");
   const handleInputChange = (e: ChangeEvent<HTMLInputElement>) => {
-    setTeamLink(e.target.value);
+    setTokenInput(e.target.value);
   };
 
   const handleButtonClick = async () => {
     try {
       await postGroupInvitation({
         userEmail: email,
-        token: teamLink,
+        token: tokenInput,
       });
       showToast("success", "팀 참여에 성공하였습니다.");
       router.push("/");
@@ -36,30 +37,31 @@ const ParticipateTeamForm = ({ email }: ParticipateTeamFormProps) => {
   };
 
   return (
-    <div className="flex w-full flex-col gap-[40px]">
-      <div className="flex flex-col gap-[12px]">
-        <p className="text-[16px] font-[500]">팀 링크</p>
-        <input
-          className="w-full rounded-xl border border-border-primary border-opacity-10 bg-background-secondary px-4 py-[13.5px] text-base font-normal placeholder:text-sm placeholder:font-normal placeholder:text-text-default focus:border-2 focus:outline-none"
-          placeholder="팀 링크를 입력해주세요."
-          value={teamLink}
-          onChange={handleInputChange}
-        />
+    <>
+      <div className="flex w-full flex-col gap-[40px]">
+        <div className="flex flex-col gap-[12px]">
+          <p className="text-[16px] font-[500]">팀 링크</p>
+          <input
+            className="w-full rounded-xl border border-border-primary border-opacity-10 bg-background-secondary px-4 py-[13.5px] text-base font-normal placeholder:text-sm placeholder:font-normal placeholder:text-text-default focus:border-2 focus:outline-none"
+            value={tokenInput}
+            onChange={handleInputChange}
+          />
+        </div>
+        <div className="flex flex-col gap-[10px]">
+          <Button
+            btnSize="large"
+            btnStyle="solid"
+            disabled={!tokenInput.trim()}
+            onClick={handleButtonClick}
+          >
+            참여하기
+          </Button>
+          <p className="text-center text-[16px] font-[400]">
+            공유받은 팀 링크를 입력해 참여할 수 있어요.
+          </p>
+        </div>
       </div>
-      <div className="flex flex-col gap-[10px]">
-        <Button
-          btnSize="large"
-          btnStyle="solid"
-          disabled={!teamLink.trim()}
-          onClick={handleButtonClick}
-        >
-          참여하기
-        </Button>
-        <p className="text-center text-[16px] font-[400]">
-          공유받은 팀 링크를 입력해 참여할 수 있어요.
-        </p>
-      </div>
-    </div>
+    </>
   );
 };
 

--- a/app/(team-setting)/participate-team/_components/participate-team-form.tsx
+++ b/app/(team-setting)/participate-team/_components/participate-team-form.tsx
@@ -19,11 +19,7 @@ const ParticipateTeamForm = ({ email }: ParticipateTeamFormProps) => {
   const router = useRouter();
   const searchParams = useSearchParams();
 
-  const {
-    register,
-    handleSubmit,
-    formState: { errors },
-  } = useForm<TeamLinkFormValues>({
+  const { register, handleSubmit } = useForm<TeamLinkFormValues>({
     defaultValues: {
       token: searchParams.get("token") || "",
     },

--- a/app/(team-setting)/participate-team/page.tsx
+++ b/app/(team-setting)/participate-team/page.tsx
@@ -1,10 +1,14 @@
+import { getUser } from "@/app/action";
+
 import ParticipateTeamForm from "./_components/participate-team-form";
 
-export default function Page() {
+export default async function Page() {
+  const result = await getUser();
+
   return (
     <div className="flex w-full flex-col items-center justify-center gap-[80px] pt-[140px] text-text-primary">
       <h1 className="text-[40px] font-[500]">팀 참여하기</h1>
-      <ParticipateTeamForm />
+      <ParticipateTeamForm email={result.email} />
     </div>
   );
 }

--- a/app/(team-setting)/participate-team/page.tsx
+++ b/app/(team-setting)/participate-team/page.tsx
@@ -1,3 +1,10 @@
+import ParticipateTeamForm from "./_components/participate-team-form";
+
 export default function Page() {
-  return <div></div>;
+  return (
+    <div className="flex w-full flex-col items-center justify-center gap-[80px] pt-[140px] text-text-primary">
+      <h1 className="text-[40px] font-[500]">팀 참여하기</h1>
+      <ParticipateTeamForm />
+    </div>
+  );
 }

--- a/app/(team-setting)/participate-team/page.tsx
+++ b/app/(team-setting)/participate-team/page.tsx
@@ -1,4 +1,4 @@
-import { getUser } from "@/app/action";
+import { getUser } from "@/lib/apis/user";
 
 import ParticipateTeamForm from "./_components/participate-team-form";
 

--- a/app/[groupId]/_components/modal/modal-member-invitation.tsx
+++ b/app/[groupId]/_components/modal/modal-member-invitation.tsx
@@ -18,7 +18,9 @@ const ModalMemberInvitation = ({
   const handleButtonClick = async () => {
     try {
       const result = await getGroupInvitation({ groupId: groupId });
-      await navigator.clipboard.writeText(result);
+      await navigator.clipboard.writeText(
+        `${process.env.NEXT_PUBLIC_PARTICIPATE_TEAM_REDIRECT_URL}?token=${result}`,
+      );
       showToast("success", "링크가 복사되었습니다");
       close();
     } catch (error) {

--- a/components/header/popover-trigger.tsx
+++ b/components/header/popover-trigger.tsx
@@ -34,6 +34,7 @@ export default function PopoverTrigger({ nickname }: PopoverTriggerProps) {
           },
           {
             text: LOGGED_IN_USER_CONTENT[2],
+            onClick: () => router.push("/participate-team"),
           },
           {
             text: LOGGED_IN_USER_CONTENT[3],

--- a/lib/apis/group/index.ts
+++ b/lib/apis/group/index.ts
@@ -97,7 +97,7 @@ export async function deleteGroup({ groupId }: DeleteGroupProps) {
   }
 }
 
-interface postGroupInvitationProps {
+interface PostGroupInvitationProps {
   userEmail: string;
   token: string;
 }
@@ -106,7 +106,7 @@ interface postGroupInvitationProps {
 export async function postGroupInvitation({
   userEmail,
   token,
-}: postGroupInvitationProps) {
+}: PostGroupInvitationProps) {
   try {
     const response = await myFetch<GetTeamIdGroupsIdInvitationResponse>(
       `${process.env.NEXT_PUBLIC_KKOM_KKOM_URL}/groups/accept-invitation`,

--- a/lib/apis/group/index.ts
+++ b/lib/apis/group/index.ts
@@ -1,4 +1,5 @@
 import { myFetch } from "../myFetch";
+import { ResponseError } from "../myFetch/clientFetch";
 import {
   GetTeamIdGroupsIdInvitationResponse,
   GetTeamIdGroupsIdResponse,
@@ -114,11 +115,19 @@ export async function postGroupInvitation({
         headers: {
           "Content-Type": "application/json",
         },
+        withCredentials: true,
         body: JSON.stringify({ userEmail, token }),
       },
     );
     return response;
   } catch (error) {
-    throw error;
+    if (error instanceof ResponseError && error.response) {
+      const response: { message: string } = await error.response?.json();
+      if (response) {
+        throw new Error(response.message);
+      }
+    } else {
+      throw error;
+    }
   }
 }

--- a/lib/apis/group/index.ts
+++ b/lib/apis/group/index.ts
@@ -95,3 +95,30 @@ export async function deleteGroup({ groupId }: DeleteGroupProps) {
     throw error;
   }
 }
+
+interface postGroupInvitationProps {
+  userEmail: string;
+  token: string;
+}
+
+//NOTE - 그룹 참여
+export async function postGroupInvitation({
+  userEmail,
+  token,
+}: postGroupInvitationProps) {
+  try {
+    const response = await myFetch<GetTeamIdGroupsIdInvitationResponse>(
+      `${process.env.NEXT_PUBLIC_KKOM_KKOM_URL}/groups/accept-invitation`,
+      {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+        },
+        body: JSON.stringify({ userEmail, token }),
+      },
+    );
+    return response;
+  } catch (error) {
+    throw error;
+  }
+}


### PR DESCRIPTION
<!-- PR 제목은 커밋 메세지 컨벤션 형식으로 작성 -->

## 🏷️ 이슈 번호 #124

- close #124

## 🧱 작업 사항

- 팀 참여하기 페이지 UI를 구현하였습니다.
- 팀 참여하기 기능을 구현하였습니다.
   - 서버에서 던져주는 에러 메세지를 그대로 사용하도록 했습니다. (e.g. 유효하지 않은 토큰, 이미 참여한 팀)

## 📸 결과물

https://github.com/user-attachments/assets/53eb85fc-912d-4897-9a84-62af7fedb5ff


## 💬 공유 포인트 및 논의 사항
