### PR TITLE
feat: 계정 설정 페이지 구현 

### DIFF
--- a/app/mypage/_component/modal-reset-password.tsx
+++ b/app/mypage/_component/modal-reset-password.tsx
@@ -1,12 +1,54 @@
+import { ResetPasswordInputValue } from "@/app/(auth)/reset-password/_components/reset-password-form";
+import Button from "@/components/button/button";
+import PasswordInput from "@/components/input-field/password-input";
 import Modal from "@/components/modal/modal";
+import { resetPasswordSchema } from "@/schemas/auth";
+import { yupResolver } from "@hookform/resolvers/yup";
+import { SubmitHandler, useForm } from "react-hook-form";
 
 interface ModalResetPasswordProps {
   close: () => void;
 }
 export default function ModalResetPassword({ close }: ModalResetPasswordProps) {
+  const {
+    register,
+    handleSubmit,
+    formState: { errors, isValid },
+  } = useForm<ResetPasswordInputValue>({
+    resolver: yupResolver(resetPasswordSchema),
+    mode: "onChange",
+  });
+
   return (
-    <Modal close={close} closeOnFocusOut>
+    <Modal close={close} closeOnFocusOut className="p-[36px]">
       <Modal.Title>비밀번호 변경하기</Modal.Title>
+      <form>
+        <div className="mb-6 mt-4 flex flex-col gap-4">
+          <PasswordInput<ResetPasswordInputValue>
+            id="password"
+            placeholder="새 비밀번호를 입력해 주세요"
+            label="새 비밀번호"
+            error={errors.password?.message}
+            register={register}
+            isModal={true}
+          />
+          <PasswordInput<ResetPasswordInputValue>
+            id="passwordConfirmation"
+            placeholder="새 비밀번호를 다시 한 번 입력해 주세요"
+            label="새 비밀번호 확인"
+            error={errors.passwordConfirmation?.message}
+            register={register}
+            isModal={true}
+          />
+        </div>
+        <Modal.TwoButtonSection
+          closeBtnStyle="outlined"
+          confirmBtnStyle="solid"
+          buttonDescription="변경하기"
+          close={close}
+          disabled={!isValid}
+        />
+      </form>
     </Modal>
   );
 }

--- a/app/mypage/_component/modal-reset-password.tsx
+++ b/app/mypage/_component/modal-reset-password.tsx
@@ -2,8 +2,11 @@ import { ResetPasswordInputValue } from "@/app/(auth)/reset-password/_components
 import Button from "@/components/button/button";
 import PasswordInput from "@/components/input-field/password-input";
 import Modal from "@/components/modal/modal";
+import { modalResetPassword } from "@/lib/apis/user";
+import { showToast } from "@/lib/show-toast";
 import { resetPasswordSchema } from "@/schemas/auth";
 import { yupResolver } from "@hookform/resolvers/yup";
+import { useMutation } from "@tanstack/react-query";
 import { SubmitHandler, useForm } from "react-hook-form";
 
 interface ModalResetPasswordProps {
@@ -19,10 +22,27 @@ export default function ModalResetPassword({ close }: ModalResetPasswordProps) {
     mode: "onChange",
   });
 
+  const mutation = useMutation({
+    mutationFn: async (data: ResetPasswordInputValue) => {
+      return await modalResetPassword(data);
+    },
+    onSuccess: (response) => {
+      showToast("success", <p>비밀번호가 변경되었습니다</p>);
+      close();
+    },
+    onError: (response) => {
+      showToast("error", <p>{response.message}</p>);
+    },
+  });
+
+  const onSubmit: SubmitHandler<ResetPasswordInputValue> = async (data) => {
+    mutation.mutate(data);
+  };
+
   return (
     <Modal close={close} closeOnFocusOut className="p-[36px]">
       <Modal.Title>비밀번호 변경하기</Modal.Title>
-      <form>
+      <form onSubmit={handleSubmit(onSubmit)}>
         <div className="mb-6 mt-4 flex flex-col gap-4">
           <PasswordInput<ResetPasswordInputValue>
             id="password"
@@ -46,7 +66,7 @@ export default function ModalResetPassword({ close }: ModalResetPasswordProps) {
           confirmBtnStyle="solid"
           buttonDescription="변경하기"
           close={close}
-          disabled={!isValid}
+          disabled={!isValid || mutation.isPending}
         />
       </form>
     </Modal>

--- a/app/mypage/_component/modal-secession.tsx
+++ b/app/mypage/_component/modal-secession.tsx
@@ -2,7 +2,7 @@ import Modal from "@/components/modal/modal";
 import { deleteAccount } from "@/lib/apis/user";
 import { showToast } from "@/lib/show-toast";
 import Alert from "@/public/icons/alert.svg";
-import { useMutation } from "@tanstack/react-query";
+import { useMutation, useQueryClient } from "@tanstack/react-query";
 import { deleteCookie } from "cookies-next";
 import { useRouter } from "next/navigation";
 

--- a/app/mypage/_component/modal-secession.tsx
+++ b/app/mypage/_component/modal-secession.tsx
@@ -1,5 +1,10 @@
 import Modal from "@/components/modal/modal";
+import { deleteAccount } from "@/lib/apis/user";
+import { showToast } from "@/lib/show-toast";
 import Alert from "@/public/icons/alert.svg";
+import { useMutation } from "@tanstack/react-query";
+import { deleteCookie } from "cookies-next";
+import { useRouter } from "next/navigation";
 
 interface ModalWarningProps {
   close: () => void;
@@ -12,8 +17,25 @@ interface ModalWarningProps {
  * @param handleConfirm 확인 버튼을 눌렀을 때 실행할 함수
  */
 export function ModalSecession({ close }: ModalWarningProps) {
+  const router = useRouter();
+  const mutation = useMutation({
+    mutationFn: async () => {
+      return await deleteAccount();
+    },
+    onSuccess: () => {
+      router.push("/");
+      deleteCookie("accessToken");
+      deleteCookie("refreshToken");
+      router.refresh();
+      close();
+      showToast("success", <p>탈퇴되었습니다.</p>);
+    },
+    onError: (response) => {
+      showToast("error", <p>{response.message}</p>);
+    },
+  });
   const handleClick = async () => {
-    close();
+    mutation.mutate();
   };
 
   return (
@@ -35,6 +57,7 @@ export function ModalSecession({ close }: ModalWarningProps) {
           buttonDescription="회원 탈퇴"
           onClick={handleClick}
           close={close}
+          disabled={mutation.isPending}
         />
       </div>
     </Modal>

--- a/app/mypage/_component/update-user-form.tsx
+++ b/app/mypage/_component/update-user-form.tsx
@@ -39,7 +39,6 @@ export default function UpdateUserForm() {
     formState: { errors, isDirty, isValid },
   } = useForm<UpdateUserInputValue>({
     mode: "onChange",
-
     resolver: yupResolver(updateUserSchema),
   });
 

--- a/app/mypage/_component/update-user-form.tsx
+++ b/app/mypage/_component/update-user-form.tsx
@@ -12,6 +12,7 @@ import { showToast } from "@/lib/show-toast";
 import { updateUserSchema } from "@/schemas/user";
 import { yupResolver } from "@hookform/resolvers/yup";
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+import { useRouter } from "next/navigation";
 import { useEffect } from "react";
 import { SubmitHandler, useForm } from "react-hook-form";
 
@@ -25,6 +26,7 @@ export interface UpdateUserInputValue {
 }
 
 export default function UpdateUserForm() {
+  const router = useRouter();
   const queryClient = useQueryClient();
 
   const modalResetPasswordOverlay = useCustomOverlay(({ close }) => (
@@ -41,6 +43,8 @@ export default function UpdateUserForm() {
       return await updateAccount(data);
     },
     onSuccess: () => {
+      // NOTE - 탈퇴하기 성공 후에는 router.refresh();로 헤더 업데이트됨
+      // router.refresh();
       // NOTE - queryclientrefetchqueries랑 같은 동작 뭘 사용 ?
       queryClient.invalidateQueries({ queryKey: ["getUser"] });
       showToast("success", <p>정보가 변경되었습니다.</p>);

--- a/app/mypage/_component/update-user-form.tsx
+++ b/app/mypage/_component/update-user-form.tsx
@@ -5,36 +5,63 @@ import { BasicInput } from "@/components/input-field/basic-input";
 import PasswordInput from "@/components/input-field/password-input";
 import { ProfileInput } from "@/components/profile-input/profile-input";
 import { useCustomOverlay } from "@/hooks/use-custom-overlay";
-import { getUser } from "@/lib/apis/user";
+import { uploadImage } from "@/lib/apis/image";
+import { ResponseError } from "@/lib/apis/myFetch/clientFetch";
+import { getUser, updateAccount } from "@/lib/apis/user";
+import { showToast } from "@/lib/show-toast";
 import { updateUserSchema } from "@/schemas/user";
 import { yupResolver } from "@hookform/resolvers/yup";
-import { useQuery } from "@tanstack/react-query";
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+import { useRouter } from "next/navigation";
 import { useEffect } from "react";
 import { SubmitHandler, useForm } from "react-hook-form";
 
 import ModalResetPassword from "./modal-reset-password";
 
-interface UpdateUserInputValue {
-  nickname: string;
+export interface UpdateUserInputValue {
+  nickname?: string;
   image?: File | string;
   password?: string;
   email?: string;
 }
 
 export default function UpdateUserForm() {
+  const queryClient = useQueryClient();
+
   const modalResetPasswordOverlay = useCustomOverlay(({ close }) => (
     <ModalResetPassword close={close} />
   ));
 
   const { data, isSuccess } = useQuery({
-    queryKey: ["posts"],
+    queryKey: ["getUser"],
     queryFn: getUser,
+  });
+
+  const mutation = useMutation({
+    mutationFn: async (data: UpdateUserInputValue) => {
+      return await updateAccount(data);
+    },
+    onSuccess: () => {
+      // NOTE - queryclientrefetchqueries랑 같은 동작 뭘 사용 ?
+      queryClient.invalidateQueries({ queryKey: ["getUser"] });
+      showToast("success", <p>정보가 변경되었습니다.</p>);
+    },
+    onError: async (error) => {
+      if (error instanceof ResponseError) {
+        const response = (await error.response?.json()) as { message: string };
+        showToast("error", <p>{response.message}</p>);
+        return;
+      } else {
+        showToast("error", <p>다시 시도해 주세요</p>);
+      }
+    },
   });
 
   const {
     register,
     handleSubmit,
     setValue,
+    watch,
     reset,
     formState: { errors, isDirty, isValid },
   } = useForm<UpdateUserInputValue>({
@@ -57,10 +84,29 @@ export default function UpdateUserForm() {
     return null;
   }
 
-  const { image, email } = data;
+  const { image, email, nickname } = data;
+  const watchedNickname = watch("nickname", nickname) || "";
 
   const onSubmit: SubmitHandler<UpdateUserInputValue> = async (data) => {
-    console.log(data);
+    if (data.nickname === nickname) {
+      delete data.nickname;
+    }
+
+    if (data.image instanceof File) {
+      try {
+        const imageToStringResponse = await uploadImage(data.image);
+        data.image = imageToStringResponse.url;
+      } catch (error) {
+        if (error instanceof ResponseError) {
+          showToast("error", <p>{error.message}</p>);
+          return;
+        } else {
+          showToast("error", <p>다시 시도해 주세요</p>);
+          return;
+        }
+      }
+    }
+    mutation.mutate(data);
   };
 
   return (
@@ -100,7 +146,7 @@ export default function UpdateUserForm() {
         btnSize="x-small"
         btnStyle="solid"
         className="absolute right-0 top-0 ml-auto flex w-[80px]"
-        disabled={!isDirty || !isValid}
+        disabled={!isDirty || !isValid || watchedNickname.trim() === ""}
       >
         수정하기
       </Button>

--- a/app/mypage/_component/update-user-form.tsx
+++ b/app/mypage/_component/update-user-form.tsx
@@ -43,8 +43,6 @@ export default function UpdateUserForm() {
       return await updateAccount(data);
     },
     onSuccess: () => {
-      // NOTE - 탈퇴하기 성공 후에는 router.refresh();로 헤더 업데이트됨
-      // router.refresh();
       // NOTE - queryclientrefetchqueries랑 같은 동작 뭘 사용 ?
       queryClient.invalidateQueries({ queryKey: ["getUser"] });
       showToast("success", <p>정보가 변경되었습니다.</p>);

--- a/app/mypage/_component/update-user-form.tsx
+++ b/app/mypage/_component/update-user-form.tsx
@@ -12,7 +12,6 @@ import { showToast } from "@/lib/show-toast";
 import { updateUserSchema } from "@/schemas/user";
 import { yupResolver } from "@hookform/resolvers/yup";
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
-import { useRouter } from "next/navigation";
 import { useEffect } from "react";
 import { SubmitHandler, useForm } from "react-hook-form";
 
@@ -88,10 +87,12 @@ export default function UpdateUserForm() {
   const watchedNickname = watch("nickname", nickname) || "";
 
   const onSubmit: SubmitHandler<UpdateUserInputValue> = async (data) => {
+    // NOTE - 닉네임 변경하지 않는 경우 data에 포함 X
     if (data.nickname === nickname) {
       delete data.nickname;
     }
 
+    // NOTE - image가 파일인 경우 url로 변환
     if (data.image instanceof File) {
       try {
         const imageToStringResponse = await uploadImage(data.image);
@@ -146,7 +147,12 @@ export default function UpdateUserForm() {
         btnSize="x-small"
         btnStyle="solid"
         className="absolute right-0 top-0 ml-auto flex w-[80px]"
-        disabled={!isDirty || !isValid || watchedNickname.trim() === ""}
+        disabled={
+          !isDirty ||
+          !isValid ||
+          watchedNickname.trim() === "" ||
+          mutation.isPending
+        }
       >
         수정하기
       </Button>

--- a/components/header/LoggedIn-header-content.tsx
+++ b/components/header/LoggedIn-header-content.tsx
@@ -13,7 +13,7 @@ import PopoverTrigger from "./popover-trigger";
 
 export default function LoggedInHeaderContent() {
   const { data, isSuccess } = useQuery({
-    queryKey: ["posts"],
+    queryKey: ["getUser"],
     queryFn: getUser,
   });
 

--- a/components/header/components/modal-logout.tsx
+++ b/components/header/components/modal-logout.tsx
@@ -16,7 +16,7 @@ export default function ModalLogout({ close }: ModalLogoutProps) {
     deleteCookie("refreshToken");
     router.refresh();
     close();
-    queryClient.removeQueries({ queryKey: ["posts"] });
+    queryClient.removeQueries({ queryKey: ["getUser"] });
   }
 
   return (

--- a/components/header/components/modal-logout.tsx
+++ b/components/header/components/modal-logout.tsx
@@ -9,14 +9,12 @@ interface ModalLogoutProps {
 
 export default function ModalLogout({ close }: ModalLogoutProps) {
   const router = useRouter();
-  const queryClient = new QueryClient();
   function logout() {
     router.push("/");
     deleteCookie("accessToken");
     deleteCookie("refreshToken");
     router.refresh();
     close();
-    queryClient.removeQueries({ queryKey: ["getUser"] });
   }
 
   return (

--- a/components/header/components/modal-logout.tsx
+++ b/components/header/components/modal-logout.tsx
@@ -1,5 +1,4 @@
 import Modal from "@/components/modal/modal";
-import { QueryClient } from "@tanstack/react-query";
 import { deleteCookie } from "cookies-next";
 import { useRouter } from "next/navigation";
 

--- a/components/header/group-dropdown.tsx
+++ b/components/header/group-dropdown.tsx
@@ -2,7 +2,6 @@
 
 import { Membership } from "@/lib/apis/type";
 import Check from "@/public/icons/dropdown-check.svg";
-import Kebab from "@/public/icons/kebab-small.svg";
 import Plus from "@/public/icons/plus.svg";
 import hamster from "@/public/images/hamster.jpg";
 import Image from "next/image";
@@ -46,7 +45,7 @@ export default function GroupDropdown({ memberships }: GroupDropdownProps) {
   return (
     <div className="hidden md:block">
       <Dropdown
-        selected={`${initialGroup.group.name} 팀`}
+        selected={initialGroup.group.name}
         setSelected={setSelectedGroupName}
       >
         <Dropdown.Button className="gap-[11px] text-base font-medium text-text-primary">
@@ -56,7 +55,7 @@ export default function GroupDropdown({ memberships }: GroupDropdownProps) {
           {memberships.map((membership) => (
             <Dropdown.Item
               key={membership.group.id}
-              value={`${membership.group.name} 팀`}
+              value={membership.group.name}
             >
               <div
                 className={`flex w-full items-center justify-between rounded-lg px-2 py-[7px] hover:bg-slate-700 ${membership.group.name === selectedGroupName && "bg-slate-700"}`}
@@ -72,10 +71,9 @@ export default function GroupDropdown({ memberships }: GroupDropdownProps) {
                     />
                   </div>
                   <p className="text-base font-medium text-white">
-                    {membership.group.name} 팀
+                    {membership.group.name}
                   </p>
                 </div>
-                <Kebab width={16} height={16} />
               </div>
             </Dropdown.Item>
           ))}

--- a/components/input-field/basic-input.tsx
+++ b/components/input-field/basic-input.tsx
@@ -44,7 +44,7 @@ export function BasicInput<TFormInput extends FieldValues>({
         {label && (
           <label
             htmlFor={id}
-            className="text-base font-semibold text-text-primary"
+            className={`text-base${isModal ? "font-medium" : "font-semibold"} text-text-primary`}
           >
             {label}
           </label>

--- a/lib/apis/image/index.ts
+++ b/lib/apis/image/index.ts
@@ -1,0 +1,22 @@
+import { myFetch } from "../myFetch";
+import { PostTeamIdImagesUploadResponse } from "../type";
+
+export async function uploadImage(
+  image: File,
+): Promise<PostTeamIdImagesUploadResponse> {
+  const formData = new FormData();
+  formData.append("image", image);
+  try {
+    const response = await myFetch<PostTeamIdImagesUploadResponse>(
+      `${process.env.NEXT_PUBLIC_KKOM_KKOM_URL}/images/upload`,
+      {
+        method: "POST",
+        body: formData,
+        withCredentials: true,
+      },
+    );
+    return response;
+  } catch (error) {
+    throw error;
+  }
+}

--- a/lib/apis/user/index.ts
+++ b/lib/apis/user/index.ts
@@ -5,6 +5,7 @@ import { getCookie } from "cookies-next";
 import { myFetch } from "../myFetch";
 import { instance } from "../myFetch/instance";
 import {
+  DeleteTeamIdUserResponse,
   GetTeamIdUserGroups,
   GetTeamIdUserHistoryResponse,
   GetTeamIdUserResponse,
@@ -97,6 +98,7 @@ export async function sendEmail(
   }
 }
 
+// NOTE - 비밀번호 재설정(로그인 전)
 export async function resetPassword(data: {
   password: string;
   passwordConfirmation: string;
@@ -120,6 +122,7 @@ export async function resetPassword(data: {
   }
 }
 
+// NOTE - 비밀번호 재설정(계정 설정)
 export async function modalResetPassword(
   data: ResetPasswordInputValue,
 ): Promise<PatchTeamIdUserPasswordResponse | string> {
@@ -132,6 +135,22 @@ export async function modalResetPassword(
           "Content-Type": "application/json",
         },
         body: JSON.stringify(data),
+        withCredentials: true,
+      },
+    );
+    return response;
+  } catch (error) {
+    throw error;
+  }
+}
+
+// NOTE - 계정 탈퇴
+export async function deleteAccount(): Promise<DeleteTeamIdUserResponse> {
+  try {
+    const response = await myFetch<DeleteTeamIdUserResponse>(
+      `${process.env.NEXT_PUBLIC_KKOM_KKOM_URL}/user`,
+      {
+        method: "DELETE",
         withCredentials: true,
       },
     );

--- a/lib/apis/user/index.ts
+++ b/lib/apis/user/index.ts
@@ -1,4 +1,5 @@
 import { SendEmailInputValue } from "@/app/(auth)/reset-password/_components/modal-send-email";
+import { ResetPasswordInputValue } from "@/app/(auth)/reset-password/_components/reset-password-form";
 import { getCookie } from "cookies-next";
 
 import { myFetch } from "../myFetch";
@@ -7,6 +8,7 @@ import {
   GetTeamIdUserGroups,
   GetTeamIdUserHistoryResponse,
   GetTeamIdUserResponse,
+  PatchTeamIdUserPasswordResponse,
   PatchTeamIdUserResetPasswordResponse,
   PostTeamIdUserSendResetPasswordEmailResponse,
 } from "../type";
@@ -112,6 +114,27 @@ export async function resetPassword(data: {
       },
     );
 
+    return response;
+  } catch (error) {
+    throw error;
+  }
+}
+
+export async function modalResetPassword(
+  data: ResetPasswordInputValue,
+): Promise<PatchTeamIdUserPasswordResponse | string> {
+  try {
+    const response = await myFetch<PatchTeamIdUserPasswordResponse>(
+      `${process.env.NEXT_PUBLIC_KKOM_KKOM_URL}/user/password`,
+      {
+        method: "PATCH",
+        headers: {
+          "Content-Type": "application/json",
+        },
+        body: JSON.stringify(data),
+        withCredentials: true,
+      },
+    );
     return response;
   } catch (error) {
     throw error;

--- a/lib/apis/user/index.ts
+++ b/lib/apis/user/index.ts
@@ -1,5 +1,6 @@
 import { SendEmailInputValue } from "@/app/(auth)/reset-password/_components/modal-send-email";
 import { ResetPasswordInputValue } from "@/app/(auth)/reset-password/_components/reset-password-form";
+import { UpdateUserInputValue } from "@/app/mypage/_component/update-user-form";
 import { getCookie } from "cookies-next";
 
 import { myFetch } from "../myFetch";
@@ -11,6 +12,7 @@ import {
   GetTeamIdUserResponse,
   PatchTeamIdUserPasswordResponse,
   PatchTeamIdUserResetPasswordResponse,
+  PatchTeamIdUserResponse,
   PostTeamIdUserSendResetPasswordEmailResponse,
 } from "../type";
 
@@ -151,6 +153,28 @@ export async function deleteAccount(): Promise<DeleteTeamIdUserResponse> {
       `${process.env.NEXT_PUBLIC_KKOM_KKOM_URL}/user`,
       {
         method: "DELETE",
+        withCredentials: true,
+      },
+    );
+    return response;
+  } catch (error) {
+    throw error;
+  }
+}
+
+// NOTE - 계정 수정 (닉네임, 이미지)
+export async function updateAccount(
+  data: UpdateUserInputValue,
+): Promise<PatchTeamIdUserResponse> {
+  try {
+    const response = await myFetch<PatchTeamIdUserResponse>(
+      `${process.env.NEXT_PUBLIC_KKOM_KKOM_URL}/user`,
+      {
+        method: "PATCH",
+        headers: {
+          "Content-Type": "application/json",
+        },
+        body: JSON.stringify(data),
         withCredentials: true,
       },
     );

--- a/schemas/user.ts
+++ b/schemas/user.ts
@@ -1,10 +1,7 @@
 import * as yup from "yup";
 
 export const updateUserSchema = yup.object().shape({
-  nickname: yup
-    .string()
-    .max(30, "닉네임은 최대 30자까지 가능합니다.")
-    .required("닉네임을 입력해 주세요."),
+  nickname: yup.string().max(30, "닉네임은 최대 30자까지 가능합니다."),
   image: yup
     .mixed<File | string>()
     .test("fileOrString", "JPG, JPEG, PNG 파일만 가능합니다.", (value) => {


### PR DESCRIPTION
## 🏷️ 이슈 번호 #132 

- close #132 

## 🧱 작업 사항
- 사용자 정보 input 기본값 설정 
- 탈퇴하기 기능 구현 
   - 탈퇴 후 랜딩으로 리다이렉트
- 비밀번호 재설정 구현 
- 닉네임, 이미지 수정 구현 
   - 닉네임 중복일 경우 에러 토스트 

## 📸 결과물
![image](https://github.com/user-attachments/assets/2f517708-028e-4948-8e2d-88339327d53b)
![image](https://github.com/user-attachments/assets/63baf112-64b5-44f0-bb68-e49a1a00b2fc)
![image](https://github.com/user-attachments/assets/79246e40-3eb7-4c42-920e-b3e71dc8c656)
![image](https://github.com/user-attachments/assets/554fd0de-e3bf-47db-8d53-dda1289b23bc)


## 💬 공유 포인트 및 논의 사항
- 계정 정보 수정 후 헤더와 계정 설정 페이지 데이터를 최신 데이터로 업데이트 해줘야 해서 `invalidateQueries` 로 무효화해주었습니다 
- 헤더랑 마이페이지에서 프리패치가 각각 적용되다 보니 계정 설정 페이지만 데이터가 업데이트 되고 헤더는 업데이트가 안 돼요 ... 쿼리키만 같으면 둘다 무효화될 줄 알았는데 이게 HydrationBoundary 안에서의 쿼리만 해당하는 거 같아요 ..? 쩝 
- 탈퇴하기는 router.refresh()로 로그인하기 전 헤더로 렌더링되었는데 요놈은 헤더가 업데이트가 안 돼요 !! 탈퇴하기는 왜 또 리프레쉬로 되는 건지 헷갈려요 ㅇㅂㅇ 토큰 여부로 렌더링해 줘서 그런 걸까여 .. 
- 
