### PR TITLE
fix: 드롭다운 새로고침 버그 해결 

### DIFF
--- a/app/(free-board)/boards/_components/ordered-by-selector.tsx
+++ b/app/(free-board)/boards/_components/ordered-by-selector.tsx
@@ -32,7 +32,12 @@ export default function OrderedBySelector() {
   );
 
   return (
-    <Dropdown defaultSelected="최신순">
+    <Dropdown
+      selected={
+        options.find((option) => option.value === orderBy)?.display || "최신순"
+      }
+      setSelected={handleOrderBy}
+    >
       <section className="text-xs md:text-sm">
         <Dropdown.Button className="h-10 !w-[94px] justify-between rounded-xl bg-background-tertiary px-[14px] md:h-11 md:!w-[120px]">
           <ToggleClose
@@ -46,7 +51,7 @@ export default function OrderedBySelector() {
             <Dropdown.Item
               key={i}
               className={`h-10 w-[94px] border-b border-text-default first:rounded-t-xl last:rounded-b-xl last:border-b-0 hover:text-[#41ff30] hover:underline md:h-11 md:w-[120px] ${orderBy === option.value ? "text-[#41ff30]" : ""}`}
-              display={option.display}
+              value={option.display}
             >
               <Link
                 href={pathName + "?" + handleOrderBy(option.value)}

--- a/components/button/variants/index.ts
+++ b/components/button/variants/index.ts
@@ -23,7 +23,7 @@ export const buttonVariants = cva(
         outlined_secondary:
           "border-text-secondary text-text-default bg-white border border-solid",
         gradient: "bg-gradient text-white",
-        none_background: "border border-slate-50",
+        none_background: "border border-slate-50 text-white font-medium",
       },
     },
     defaultVariants: {

--- a/components/dropdown/dropdown.tsx
+++ b/components/dropdown/dropdown.tsx
@@ -13,8 +13,8 @@ import {
 interface DropdownState {
   isDropdownOpen: boolean;
   handleDropdown: () => void;
-  selected: ReactNode;
-  handleSelect: (display: ReactNode, value: ReactNode) => void;
+  selected: string;
+  handleSelect: (value: string) => void;
 }
 
 // NOTE - 컨텍스트 생성
@@ -31,7 +31,8 @@ export function useDropdown() {
 
 interface DropdownProps {
   children: ReactNode;
-  defaultSelected: ReactNode;
+  selected: string;
+  setSelected: (value: string) => void;
 }
 
 /**
@@ -40,13 +41,9 @@ interface DropdownProps {
  * @param defaultSelected : 기본적으로 드롭다운 버튼에 보일 내용입니다.
  * @example    <Dropdown defaultSelected="항목을 선택하세요">...</Dropdown>
  **/
-export function Dropdown({ children, defaultSelected }: DropdownProps) {
+export function Dropdown({ children, selected, setSelected }: DropdownProps) {
   const [isDropdownOpen, setIsDropdownOpen] = useState(false);
-  const [selected, setSelected] = useState<ReactNode>(defaultSelected);
-
-  const handleSelect = (display: ReactNode | undefined, value: ReactNode) => {
-    setSelected(display || value);
-  };
+  const handleSelect = (value: string) => setSelected(value);
   const handleDropdown = () => setIsDropdownOpen((prev) => !prev);
 
   // NOTE - 드롭다운이 열려있는 경우 외부 영역 클릭하면 닫히도록 하는 함수
@@ -131,7 +128,7 @@ function Body({ children, className, ...rest }: BodyProps) {
 // NOTE - Item
 interface ItemProps extends OlHTMLAttributes<HTMLLIElement> {
   children: ReactNode;
-  display?: ReactNode;
+  value: string;
 }
 
 /**
@@ -139,14 +136,13 @@ interface ItemProps extends OlHTMLAttributes<HTMLLIElement> {
  * 드롭다운 선택 항목에 대한 컴포넌트입니다.
  * @param children : li 안에 포함될 내용을 적습니다
  * @param className : 너비 및 배경색 등 추가적으로 적용될 스타일을 지정해주는 프롭입니다.
- * @param display : 선택 항목에 표시할 내용입니다. 없는 경우 children을 사용합니다.
- * @example  <Dropdown.Item><div className="flex gap-2"><p>Seo</p><span>Young</span></div></Dropdown.Item>
+ * @example  <Dropdown.Item   value={`${membership.group.name} 팀`}><div className="flex gap-2"><p>Seo</p><span>Young</span></div></Dropdown.Item>
  **/
-function Item({ children, display, ...rest }: ItemProps) {
+function Item({ children, value, ...rest }: ItemProps) {
   const { handleSelect, handleDropdown } = useDropdown();
 
   const onSelect = () => {
-    handleSelect(display, children);
+    handleSelect(value);
     handleDropdown();
   };
   return (

--- a/components/header/group-dropdown.tsx
+++ b/components/header/group-dropdown.tsx
@@ -24,22 +24,31 @@ export default function GroupDropdown({ memberships }: GroupDropdownProps) {
   const initialGroup =
     memberships.find((membership) => membership.group.id === currentGroupId) ||
     memberships[0];
-  const [selectedGroupId, setSelectedGroupId] = useState(initialGroup.group.id);
+  const [selectedGroupName, setSelectedGroupName] = useState(
+    initialGroup.group.name,
+  );
 
   const handleSelect = (id: number) => {
-    setSelectedGroupId(id);
     router.push(`/${id}`);
   };
 
   useEffect(() => {
     if (currentGroupId) {
-      setSelectedGroupId(currentGroupId);
+      const currentGroup = memberships.find(
+        (membership) => membership.group.id === currentGroupId,
+      );
+      if (currentGroup) {
+        setSelectedGroupName(currentGroup.group.name);
+      }
     }
-  }, [currentGroupId]);
+  }, [currentGroupId, memberships]);
 
   return (
     <div className="hidden md:block">
-      <Dropdown defaultSelected={`${initialGroup.group.name} 팀`}>
+      <Dropdown
+        selected={`${initialGroup.group.name} 팀`}
+        setSelected={setSelectedGroupName}
+      >
         <Dropdown.Button className="gap-[11px] text-base font-medium text-text-primary">
           <Check width={16} height={16} />
         </Dropdown.Button>
@@ -47,10 +56,10 @@ export default function GroupDropdown({ memberships }: GroupDropdownProps) {
           {memberships.map((membership) => (
             <Dropdown.Item
               key={membership.group.id}
-              display={`${membership.group.name} 팀`}
+              value={`${membership.group.name} 팀`}
             >
               <div
-                className={`flex w-full items-center justify-between rounded-lg px-2 py-[7px] hover:bg-slate-700 ${membership.group.id === selectedGroupId && "bg-slate-700"}`}
+                className={`flex w-full items-center justify-between rounded-lg px-2 py-[7px] hover:bg-slate-700 ${membership.group.name === selectedGroupName && "bg-slate-700"}`}
                 onClick={() => handleSelect(membership.group.id)}
               >
                 <div className="flex items-center gap-3">

--- a/components/header/group-dropdown.tsx
+++ b/components/header/group-dropdown.tsx
@@ -8,7 +8,7 @@ import hamster from "@/public/images/hamster.jpg";
 import Image from "next/image";
 import { usePathname } from "next/navigation";
 import { useRouter } from "next/navigation";
-import { useState } from "react";
+import { useEffect, useState } from "react";
 
 import { LinkButton } from "../button/button";
 import { Dropdown } from "../dropdown/dropdown";
@@ -20,18 +20,26 @@ interface GroupDropdownProps {
 export default function GroupDropdown({ memberships }: GroupDropdownProps) {
   const pathname = usePathname();
   const router = useRouter();
-  const [selectedGroupId, setSelectedGroupId] = useState(
-    memberships[0].group.id,
-  );
+  const currentGroupId = parseInt(pathname.split("/")[1], 10);
+  const initialGroup =
+    memberships.find((membership) => membership.group.id === currentGroupId) ||
+    memberships[0];
+  const [selectedGroupId, setSelectedGroupId] = useState(initialGroup.group.id);
 
   const handleSelect = (id: number) => {
     setSelectedGroupId(id);
     router.push(`/${id}`);
   };
 
+  useEffect(() => {
+    if (currentGroupId) {
+      setSelectedGroupId(currentGroupId);
+    }
+  }, [currentGroupId]);
+
   return (
     <div className="hidden md:block">
-      <Dropdown defaultSelected={`${memberships[0].group.name} 팀`}>
+      <Dropdown defaultSelected={`${initialGroup.group.name} 팀`}>
         <Dropdown.Button className="gap-[11px] text-base font-medium text-text-primary">
           <Check width={16} height={16} />
         </Dropdown.Button>

--- a/components/header/modal-side-menu.tsx
+++ b/components/header/modal-side-menu.tsx
@@ -38,11 +38,11 @@ export default function ModalSideMenu({
         <button onClick={close} className="absolute right-4 top-4">
           <CloseButton width={24} height={24} />
         </button>
-        <ul className="mt-[75px] flex flex-col gap-6 px-4 text-sm font-medium text-text-primary">
+        <ul className="mt-[75px] flex cursor-pointer flex-col gap-[20px] px-4 text-sm font-medium text-text-primary">
           {memberships.map((membership) => (
             <li
               key={membership.group.id}
-              className="flex items-center gap-3"
+              className="flex h-[35px] items-center gap-3 rounded-lg px-[3px] transition-all duration-100 hover:bg-slate-700"
               onClick={() => handleRoute(membership.group.id)}
             >
               <div className="relative size-6 overflow-hidden rounded-md">
@@ -56,12 +56,18 @@ export default function ModalSideMenu({
               <p> {membership.group.name} 팀</p>
             </li>
           ))}
-          <li className="flex items-center gap-3" onClick={close}>
+          <li
+            className="flex h-[35px] items-center gap-3 rounded-lg px-[3px] transition-all duration-100 hover:bg-slate-700"
+            onClick={close}
+          >
             {/* <Plus width={18} height={18} /> */}
             🌈
             <Link href="/addteam">팀 추가하기</Link>
           </li>
-          <li className="flex items-center gap-3" onClick={close}>
+          <li
+            className="flex h-[35px] items-center gap-3 rounded-lg px-[3px] transition-all duration-100 hover:bg-slate-700"
+            onClick={close}
+          >
             {/* <Plus width={18} height={18} /> */}
             📋
             <Link href="/boards">자유게시판</Link>


### PR DESCRIPTION
## 🏷️ 이슈 번호 #154 

- close #154 

## 🧱 작업 사항
- /[groupId] 에서 새로고침해도 페이지에 해당하는 팀명이 보이도록 수정 
- 모바일에서 쓰이는 사이드바 hover 스타일 추가 
- 드롭다운 팀 추가하기 버튼 text 색상 설정 

## 📸 결과물

https://github.com/user-attachments/assets/04acc39d-920a-4c13-9210-d90a39774ac1

https://github.com/user-attachments/assets/5643cfb7-438c-47c5-b261-05b7169ba043


## 💬 공유 포인트 및 논의 사항
- 쿼리 스트링이 아니라 `usePathname` 훅을 사용했습니다 ! 
