### PR TITLE
feat: 팀 페이지 관리자용, 멤버용 분리

### DIFF
--- a/app/[groupId]/_components/member-list.tsx
+++ b/app/[groupId]/_components/member-list.tsx
@@ -16,6 +16,7 @@ interface MemberCardProps {
 }
 
 interface MemberListProps {
+  isAdmin: boolean;
   members: MemberType[];
   groupId: string;
 }
@@ -60,8 +61,7 @@ const MemberCard = ({ member }: MemberCardProps) => {
   );
 };
 
-//TODO - admin인지 member인지 확인한 뒤에 <+ 새로운 멤버 초대하기> 렌더링하기
-const MemberList = ({ members, groupId }: MemberListProps) => {
+const MemberList = ({ isAdmin, members, groupId }: MemberListProps) => {
   const ModalMemberAddOverlay = useCustomOverlay(({ close }) => (
     <ModalMemberInvitation close={close} groupId={groupId} />
   ));
@@ -75,12 +75,14 @@ const MemberList = ({ members, groupId }: MemberListProps) => {
             ({members.length}명)
           </p>
         </div>
-        <button
-          onClick={ModalMemberAddOverlay.open}
-          className="text-[14px] font-[400] text-brand-primary"
-        >
-          + 새로운 멤버 초대하기
-        </button>
+        {isAdmin && (
+          <button
+            onClick={ModalMemberAddOverlay.open}
+            className="text-[14px] font-[400] text-brand-primary"
+          >
+            + 새로운 멤버 초대하기
+          </button>
+        )}
       </div>
       <div className="grid h-[170px] grid-cols-2 gap-[16px] overflow-y-scroll scrollbar-custom md:grid-cols-3 md:gap-[24px]">
         {members.length > 0 ? (

--- a/app/[groupId]/_components/task-lists.tsx
+++ b/app/[groupId]/_components/task-lists.tsx
@@ -18,6 +18,7 @@ interface TaskListProps {
 }
 
 interface TaskListsProps {
+  isAdmin: boolean;
   taskLists: TaskListType[];
 }
 
@@ -79,7 +80,7 @@ const TaskList = ({ taskList }: TaskListProps) => {
   );
 };
 
-const TaskLists = ({ taskLists }: TaskListsProps) => {
+const TaskLists = ({ isAdmin, taskLists }: TaskListsProps) => {
   const ModalTaskListAddOverlay = useCustomOverlay(({ close }) => (
     <ModalTaskListAdd close={close} />
   ));
@@ -93,12 +94,14 @@ const TaskLists = ({ taskLists }: TaskListsProps) => {
             ({taskLists.length}개)
           </p>
         </div>
-        <button
-          className="text-[14px] font-[400] text-brand-primary"
-          onClick={ModalTaskListAddOverlay.open}
-        >
-          + 새로운 목록 추가하기
-        </button>
+        {isAdmin && (
+          <button
+            className="text-[14px] font-[400] text-brand-primary"
+            onClick={ModalTaskListAddOverlay.open}
+          >
+            + 새로운 목록 추가하기
+          </button>
+        )}
       </div>
       <div className="flex h-[208px] flex-col gap-[10px] overflow-y-scroll scrollbar-custom">
         {taskLists.length > 0 ? (

--- a/app/[groupId]/_components/team-name.tsx
+++ b/app/[groupId]/_components/team-name.tsx
@@ -10,11 +10,12 @@ import ModalTeamDelete from "./modal/modal-team-delete";
 import ModalTeamNameEdit from "./modal/modal-team-name-edit";
 
 interface TeamNameProps {
+  isAdmin: boolean;
   teamName: string;
   groupId: string;
 }
 
-const TeamName = ({ teamName, groupId }: TeamNameProps) => {
+const TeamName = ({ isAdmin, teamName, groupId }: TeamNameProps) => {
   const ModalTeamNameEditOverlay = useCustomOverlay(({ close }) => (
     <ModalTeamNameEdit
       close={close}
@@ -34,16 +35,18 @@ const TeamName = ({ teamName, groupId }: TeamNameProps) => {
       </p>
       <div className="absolute flex items-center justify-center gap-[30px]">
         <Image src={Thumbnail} alt="썸네일" height={64} />
-        <Popover
-          triggerSvg={Gear}
-          triggerHeight={24}
-          triggerWidth={24}
-          content={[
-            { text: "수정하기", onClick: ModalTeamNameEditOverlay.open },
-            { text: "삭제하기", onClick: ModalTeamDeleteOverlay.open },
-          ]}
-          contentClassName="z-10 border-[1px] absolute right-0 bg-background-secondary border-border-primary/10 w-[120px] h-[80px] text-white"
-        />
+        {isAdmin && (
+          <Popover
+            triggerSvg={Gear}
+            triggerHeight={24}
+            triggerWidth={24}
+            content={[
+              { text: "수정하기", onClick: ModalTeamNameEditOverlay.open },
+              { text: "삭제하기", onClick: ModalTeamDeleteOverlay.open },
+            ]}
+            contentClassName="z-10 border-[1px] absolute right-0 bg-background-secondary border-border-primary/10 w-[120px] h-[80px] text-white"
+          />
+        )}
       </div>
     </div>
   );

--- a/app/[groupId]/page.tsx
+++ b/app/[groupId]/page.tsx
@@ -1,4 +1,5 @@
 import getGroupInfo from "@/lib/apis/group/index";
+import { getUser } from "@/lib/apis/user";
 
 import MemberList from "./_components/member-list";
 import TaskLists from "./_components/task-lists";
@@ -14,20 +15,35 @@ export default async function TeamPage({
     groupId: params.groupId,
   });
 
+  const userInfo = await getUser();
+
   if (!groupInfo) {
     return <p className="text-white">데이터 없음</p>;
   }
 
   const { name: teamName, taskLists, members } = groupInfo;
-  console.log(groupInfo);
+
+  const adminMemberName = members.find(
+    (member) => member.role === "ADMIN",
+  )?.userName;
+
+  const isAdmin = adminMemberName === userInfo.nickname ? true : false;
 
   return (
     <div className="flex flex-col justify-center gap-[24px] pt-[24px]">
-      <TeamName teamName={teamName} groupId={params.groupId} />
+      <TeamName
+        isAdmin={isAdmin}
+        teamName={teamName}
+        groupId={params.groupId}
+      />
       <div className="flex flex-col gap-[64px]">
-        <TaskLists taskLists={taskLists} />
-        <TaskReport taskLists={taskLists} />
-        <MemberList members={members} groupId={params.groupId} />
+        <TaskLists isAdmin={isAdmin} taskLists={taskLists} />
+        {isAdmin && <TaskReport taskLists={taskLists} />}
+        <MemberList
+          isAdmin={isAdmin}
+          members={members}
+          groupId={params.groupId}
+        />
       </div>
     </div>
   );


### PR DESCRIPTION
<!-- PR 제목은 커밋 메세지 컨벤션 형식으로 작성 -->

## 🏷️ 이슈 번호 #158 

- close #158

## 🧱 작업 사항
- 팀 페이지를 관리자용, 멤버용으로 구분하였습니다.

- 관리자용
  - 팀 명 수정, 삭제 톱니바퀴 O 
  - 할 일 목록 추가하기 O
  - 팀 리포트 O
  - 멤버 초대하기 O

- 멤버용
  - 팀 명 수정, 삭제 톱니바퀴 X
  - 할 일 목록 추가하기 X
  - 팀 리포트 X
  - 멤버 초대하기 X


## 📸 결과물
### 관리자용
<img width="1664" alt="스크린샷 2024-08-14 오전 3 03 42" src="https://github.com/user-attachments/assets/cc28676e-6a08-4752-9d51-0033e3088098">


### 멤버용
<img width="1664" alt="스크린샷 2024-08-14 오전 3 06 02" src="https://github.com/user-attachments/assets/562b4a5b-0b40-455b-a461-b62693d1f774">

## 💬 공유 포인트 및 논의 사항
