### PR TITLE
feat: 멤버 삭제 기능 구현

### DIFF
--- a/app/[groupId]/_components/member-list.tsx
+++ b/app/[groupId]/_components/member-list.tsx
@@ -16,6 +16,7 @@ type MemberType = GetTeamIdGroupsIdResponse["members"][0];
 interface MemberCardProps {
   member: MemberType;
   groupId: string;
+  isAdmin: boolean;
 }
 
 interface MemberListProps {
@@ -24,7 +25,7 @@ interface MemberListProps {
   groupId: string;
 }
 
-const MemberCard = ({ member, groupId }: MemberCardProps) => {
+const MemberCard = ({ member, groupId, isAdmin }: MemberCardProps) => {
   const ModalMemberProfileOverlay = useCustomOverlay(({ close }) => (
     <ModalMemberProfile
       close={close}
@@ -68,21 +69,23 @@ const MemberCard = ({ member, groupId }: MemberCardProps) => {
           {member.userEmail}
         </p>
       </div>
-      <div
-        onClick={(event) => {
-          event.stopPropagation(); // 클릭 이벤트 전파 중지
-        }}
-      >
-        <Popover
-          triggerSvg={Kebab}
-          triggerHeight={16}
-          triggerWidth={16}
-          content={[
-            { text: "삭제하기", onClick: ModalMemberDeleteOverlay.open },
-          ]}
-          contentClassName="z-10 border-[1px] absolute right-0 bg-background-secondary border-border-primary/10 w-[120px] h-[40px] text-white"
-        />
-      </div>
+      {isAdmin && (
+        <div
+          onClick={(event) => {
+            event.stopPropagation(); // 클릭 이벤트 전파 중지
+          }}
+        >
+          <Popover
+            triggerSvg={Kebab}
+            triggerHeight={16}
+            triggerWidth={16}
+            content={[
+              { text: "삭제하기", onClick: ModalMemberDeleteOverlay.open },
+            ]}
+            contentClassName="z-10 border-[1px] absolute right-0 bg-background-secondary border-border-primary/10 w-[120px] h-[40px] text-white"
+          />
+        </div>
+      )}
     </div>
   );
 };
@@ -113,7 +116,12 @@ const MemberList = ({ isAdmin, members, groupId }: MemberListProps) => {
       <div className="grid h-[170px] grid-cols-2 gap-[16px] overflow-y-scroll scrollbar-custom md:grid-cols-3 md:gap-[24px]">
         {members.length > 0 ? (
           members.map((member) => (
-            <MemberCard key={member.userId} member={member} groupId={groupId} />
+            <MemberCard
+              key={member.userId}
+              isAdmin={isAdmin}
+              member={member}
+              groupId={groupId}
+            />
           ))
         ) : (
           <p className="text-text-primary">아직 멤버가 없습니다</p>

--- a/app/[groupId]/_components/member-list.tsx
+++ b/app/[groupId]/_components/member-list.tsx
@@ -1,11 +1,13 @@
 "use client";
 
+import Popover from "@/components/popover/popover";
 import { useCustomOverlay } from "@/hooks/use-custom-overlay";
 import { GetTeamIdGroupsIdResponse } from "@/lib/apis/type";
 import DefaultProfile from "@/public/icons/default-profile.svg";
 import Kebab from "@/public/icons/kebab-small.svg";
 import Image from "next/image";
 
+import ModalMemberDelete from "./modal/modal-member-delete";
 import ModalMemberInvitation from "./modal/modal-member-invitation";
 import ModalMemberProfile from "./modal/modal-member-profile";
 
@@ -13,6 +15,7 @@ type MemberType = GetTeamIdGroupsIdResponse["members"][0];
 
 interface MemberCardProps {
   member: MemberType;
+  groupId: string;
 }
 
 interface MemberListProps {
@@ -21,13 +24,22 @@ interface MemberListProps {
   groupId: string;
 }
 
-const MemberCard = ({ member }: MemberCardProps) => {
+const MemberCard = ({ member, groupId }: MemberCardProps) => {
   const ModalMemberProfileOverlay = useCustomOverlay(({ close }) => (
     <ModalMemberProfile
       close={close}
       userImage={member.userImage}
       userName={member.userName}
       userEmail={member.userEmail}
+    />
+  ));
+
+  const ModalMemberDeleteOverlay = useCustomOverlay(({ close }) => (
+    <ModalMemberDelete
+      close={close}
+      groupId={groupId}
+      memberUserId={member.userId}
+      userName={member.userName}
     />
   ));
 
@@ -56,7 +68,21 @@ const MemberCard = ({ member }: MemberCardProps) => {
           {member.userEmail}
         </p>
       </div>
-      <Kebab width={16} height={16} />
+      <div
+        onClick={(event) => {
+          event.stopPropagation(); // 클릭 이벤트 전파 중지
+        }}
+      >
+        <Popover
+          triggerSvg={Kebab}
+          triggerHeight={16}
+          triggerWidth={16}
+          content={[
+            { text: "삭제하기", onClick: ModalMemberDeleteOverlay.open },
+          ]}
+          contentClassName="z-10 border-[1px] absolute right-0 bg-background-secondary border-border-primary/10 w-[120px] h-[40px] text-white"
+        />
+      </div>
     </div>
   );
 };
@@ -87,7 +113,7 @@ const MemberList = ({ isAdmin, members, groupId }: MemberListProps) => {
       <div className="grid h-[170px] grid-cols-2 gap-[16px] overflow-y-scroll scrollbar-custom md:grid-cols-3 md:gap-[24px]">
         {members.length > 0 ? (
           members.map((member) => (
-            <MemberCard key={member.userId} member={member} />
+            <MemberCard key={member.userId} member={member} groupId={groupId} />
           ))
         ) : (
           <p className="text-text-primary">아직 멤버가 없습니다</p>

--- a/app/[groupId]/_components/modal/modal-member-delete.tsx
+++ b/app/[groupId]/_components/modal/modal-member-delete.tsx
@@ -1,0 +1,62 @@
+"use client";
+
+import Modal from "@/components/modal/modal";
+import { deleteTeamMember } from "@/lib/apis/group";
+import { showToast } from "@/lib/show-toast";
+import AlertIcon from "@/public/icons/alert.svg";
+import { useRouter } from "next/navigation";
+
+interface ModalMemberDeleteProps {
+  close: () => void;
+  groupId: string;
+  memberUserId: number;
+  userName: string;
+}
+
+const ModalMemberDelete = ({
+  close,
+  groupId,
+  memberUserId,
+  userName,
+}: ModalMemberDeleteProps) => {
+  const router = useRouter();
+
+  const handleButtonClick = async () => {
+    try {
+      await deleteTeamMember({
+        groupId: groupId,
+        memberUserId: memberUserId,
+      });
+      showToast("success", <p>{userName}님이 삭제되었습니다.</p>);
+      close();
+      router.refresh();
+    } catch (error) {
+      showToast("error", <p>{userName}님 삭제에 실패하였습니다.</p>);
+      console.log(error);
+      console.error(error);
+    }
+  };
+
+  return (
+    <Modal close={close} closeOnFocusOut>
+      <div className="flex h-[173px] flex-col items-center justify-center gap-[24px]">
+        <div className="flex flex-col items-center gap-[16px]">
+          <AlertIcon width={24} height={24} />
+          <Modal.Title>{userName}님을 삭제하시겠어요?</Modal.Title>
+        </div>
+
+        <div className="w-[280px]">
+          <Modal.TwoButtonSection
+            closeBtnStyle="outlined_secondary"
+            confirmBtnStyle="danger"
+            buttonDescription="삭제하기"
+            close={close}
+            onClick={handleButtonClick}
+          />
+        </div>
+      </div>
+    </Modal>
+  );
+};
+
+export default ModalMemberDelete;

--- a/lib/apis/group/index.ts
+++ b/lib/apis/group/index.ts
@@ -1,5 +1,6 @@
 import { myFetch } from "../myFetch";
 import { ResponseError } from "../myFetch/clientFetch";
+import { instance } from "../myFetch/instance";
 import {
   DeleteTeamIdGroupsIdMemberMemberUserIdResponse,
   GetTeamIdGroupsIdInvitationResponse,
@@ -14,8 +15,8 @@ interface GetGroupInfoProps {
 //NOTE - 그룹에 대한 정보
 export async function getGroupInfo({ groupId }: GetGroupInfoProps) {
   try {
-    const response = await myFetch<GetTeamIdGroupsIdResponse>(
-      `${process.env.NEXT_PUBLIC_KKOM_KKOM_URL}/groups/${groupId}`,
+    const response = await instance<GetTeamIdGroupsIdResponse>(
+      `/groups/${groupId}`,
       {
         method: "GET",
         cache: "no-store",
@@ -36,8 +37,8 @@ interface GetGroupInvitationProps {
 //NOTE - 그룹 초대 링크
 export async function getGroupInvitation({ groupId }: GetGroupInvitationProps) {
   try {
-    const response = await myFetch<GetTeamIdGroupsIdInvitationResponse>(
-      `${process.env.NEXT_PUBLIC_KKOM_KKOM_URL}/groups/${groupId}/invitation`,
+    const response = await instance<GetTeamIdGroupsIdInvitationResponse>(
+      `/groups/${groupId}/invitation`,
       {
         method: "GET",
       },
@@ -61,8 +62,8 @@ export async function patchGroupInfo({
   name,
 }: PatchGroupNameProps) {
   try {
-    const response = await myFetch<PatchTeamIdGroupsIdResponse>(
-      `${process.env.NEXT_PUBLIC_KKOM_KKOM_URL}/groups/${groupId}`,
+    const response = await instance<PatchTeamIdGroupsIdResponse>(
+      `/groups/${groupId}`,
       {
         method: "PATCH",
         headers: {
@@ -85,8 +86,8 @@ interface DeleteGroupProps {
 //NOTE - 그룹 삭제
 export async function deleteGroup({ groupId }: DeleteGroupProps) {
   try {
-    const response = await myFetch<PatchTeamIdGroupsIdResponse>(
-      `${process.env.NEXT_PUBLIC_KKOM_KKOM_URL}/groups/${groupId}`,
+    const response = await instance<PatchTeamIdGroupsIdResponse>(
+      `/groups/${groupId}`,
       {
         method: "DELETE",
         withCredentials: true,
@@ -109,8 +110,8 @@ export async function postGroupInvitation({
   token,
 }: PostGroupInvitationProps) {
   try {
-    const response = await myFetch<GetTeamIdGroupsIdInvitationResponse>(
-      `${process.env.NEXT_PUBLIC_KKOM_KKOM_URL}/groups/accept-invitation`,
+    const response = await instance<GetTeamIdGroupsIdInvitationResponse>(
+      `/groups/accept-invitation`,
       {
         method: "POST",
         headers: {
@@ -145,8 +146,8 @@ export async function deleteTeamMember({
 }: DeleteTeamMemberProps) {
   try {
     const response =
-      await myFetch<DeleteTeamIdGroupsIdMemberMemberUserIdResponse>(
-        `${process.env.NEXT_PUBLIC_KKOM_KKOM_URL}/groups/${groupId}/member/${memberUserId}`,
+      await instance<DeleteTeamIdGroupsIdMemberMemberUserIdResponse>(
+        `/groups/${groupId}/member/${memberUserId}`,
         {
           method: "DELETE",
           withCredentials: true,

--- a/lib/apis/group/index.ts
+++ b/lib/apis/group/index.ts
@@ -1,6 +1,7 @@
 import { myFetch } from "../myFetch";
 import { ResponseError } from "../myFetch/clientFetch";
 import {
+  DeleteTeamIdGroupsIdMemberMemberUserIdResponse,
   GetTeamIdGroupsIdInvitationResponse,
   GetTeamIdGroupsIdResponse,
   PatchTeamIdGroupsIdResponse,
@@ -129,5 +130,30 @@ export async function postGroupInvitation({
     } else {
       throw error;
     }
+  }
+}
+
+interface DeleteTeamMemberProps {
+  groupId: string;
+  memberUserId: number;
+}
+
+//NOTE - 그룹 멤버 삭제
+export async function deleteTeamMember({
+  groupId,
+  memberUserId,
+}: DeleteTeamMemberProps) {
+  try {
+    const response =
+      await myFetch<DeleteTeamIdGroupsIdMemberMemberUserIdResponse>(
+        `${process.env.NEXT_PUBLIC_KKOM_KKOM_URL}/groups/${groupId}/member/${memberUserId}`,
+        {
+          method: "DELETE",
+          withCredentials: true,
+        },
+      );
+    return response;
+  } catch (error) {
+    throw error;
   }
 }

--- a/lib/apis/type/index.ts
+++ b/lib/apis/type/index.ts
@@ -236,6 +236,8 @@ export type GetTeamIdGroupsIdMemberMemberUserIdResponse = {
   userId: number;
 };
 
+export type DeleteTeamIdGroupsIdMemberMemberUserIdResponse = {};
+
 // TODO: Fix the type 기획서가 제대로 정의되지 않았습니다. -> 제가 수정했어요 (지현이)
 export type GetTeamIdGroupsIdInvitationResponse = string;
 


### PR DESCRIPTION
<!-- PR 제목은 커밋 메세지 컨벤션 형식으로 작성 -->

## 🏷️ 이슈 번호 #163 

- close #163

## 🧱 작업 사항

- group api에 instance를 적용하였습니다.
- 팀 페이지에서 멤버 삭제 기능을 구현하였습니다.
- admin에게만 삭제 케밥 버튼이 보이도록 구현하였습니다.

## 📸 결과물

https://github.com/user-attachments/assets/b5b5a7e2-9c82-4a24-a1b4-aabfd431d856



## 💬 공유 포인트 및 논의 사항
