### PR TITLE
fix: 드롭다운 관련 버그 해결 및 더보기, 숨기기 버튼 추가 

### DIFF
--- a/components/dropdown/dropdown.tsx
+++ b/components/dropdown/dropdown.tsx
@@ -70,6 +70,7 @@ export function Dropdown({ children, selected, setSelected }: DropdownProps) {
 Dropdown.Button = Button;
 Dropdown.Body = Body;
 Dropdown.Item = Item;
+Dropdown.CloseItem = CloseItem;
 
 // NOTE - Button
 
@@ -147,6 +148,28 @@ function Item({ children, value, ...rest }: ItemProps) {
   };
   return (
     <li className="cursor-pointer" onClick={onSelect} {...rest}>
+      {children}
+    </li>
+  );
+}
+
+// NOTE - CloseItem
+/**
+ * @author 김서영
+ * 드롭다운을 닫기만 하는 컴포넌트입니다.
+ * @param children : li 안에 포함될 내용을 적습니다.
+ * @param className : 너비 및 배경색 등 추가적으로 적용될 스타일을 지정해주는 프롭입니다.
+ * @example  <Dropdown.CloseItem>닫기</Dropdown.CloseItem>
+ **/
+function CloseItem({ children, ...rest }: OlHTMLAttributes<HTMLLIElement>) {
+  const { handleDropdown } = useDropdown();
+
+  const onClose = () => {
+    handleDropdown();
+  };
+
+  return (
+    <li className="cursor-pointer" onClick={onClose} {...rest}>
       {children}
     </li>
   );

--- a/components/header/group-dropdown.tsx
+++ b/components/header/group-dropdown.tsx
@@ -10,7 +10,7 @@ import { useRouter } from "next/navigation";
 import { useEffect, useState } from "react";
 
 import { LinkButton } from "../button/button";
-import { Dropdown, useDropdown } from "../dropdown/dropdown";
+import { Dropdown } from "../dropdown/dropdown";
 
 interface GroupDropdownProps {
   memberships: Membership[];
@@ -19,6 +19,7 @@ interface GroupDropdownProps {
 export default function GroupDropdown({ memberships }: GroupDropdownProps) {
   const pathname = usePathname();
   const router = useRouter();
+  const [visibleCount, setVisibleCount] = useState(4);
   const currentGroupId = parseInt(pathname.split("/")[1], 10);
   const initialGroup =
     memberships.find((membership) => membership.group.id === currentGroupId) ||
@@ -27,6 +28,14 @@ export default function GroupDropdown({ memberships }: GroupDropdownProps) {
 
   const handleSelect = (id: number) => {
     router.push(`/${id}`);
+  };
+
+  const handleShowMore = () => {
+    setVisibleCount((prevCount) => prevCount + 4);
+  };
+
+  const handleShowLess = () => {
+    setVisibleCount(4);
   };
 
   useEffect(() => {
@@ -55,7 +64,7 @@ export default function GroupDropdown({ memberships }: GroupDropdownProps) {
           <Check width={16} height={16} />
         </Dropdown.Button>
         <Dropdown.Body className="mt-7 flex w-[218px] flex-col gap-2 rounded-xl bg-background-secondary p-4">
-          {memberships.map((membership) => (
+          {memberships.slice(0, visibleCount).map((membership) => (
             <Dropdown.Item
               key={membership.group.id}
               value={membership.group.name}
@@ -81,6 +90,24 @@ export default function GroupDropdown({ memberships }: GroupDropdownProps) {
               </div>
             </Dropdown.Item>
           ))}
+          {/* TODO - 더보기 버튼 */}
+          {memberships.length > visibleCount ? (
+            <button
+              onClick={handleShowMore}
+              className="flex w-full justify-center rounded-lg py-[7px] text-white hover:underline"
+            >
+              더보기
+            </button>
+          ) : (
+            visibleCount > 4 && (
+              <button
+                onClick={handleShowLess}
+                className="flex w-full justify-center rounded-lg py-[7px] text-white hover:underline"
+              >
+                숨기기
+              </button>
+            )
+          )}
           <Dropdown.CloseItem>
             <LinkButton
               btnSize="large"

--- a/components/header/group-dropdown.tsx
+++ b/components/header/group-dropdown.tsx
@@ -10,7 +10,7 @@ import { useRouter } from "next/navigation";
 import { useEffect, useState } from "react";
 
 import { LinkButton } from "../button/button";
-import { Dropdown } from "../dropdown/dropdown";
+import { Dropdown, useDropdown } from "../dropdown/dropdown";
 
 interface GroupDropdownProps {
   memberships: Membership[];
@@ -23,9 +23,7 @@ export default function GroupDropdown({ memberships }: GroupDropdownProps) {
   const initialGroup =
     memberships.find((membership) => membership.group.id === currentGroupId) ||
     memberships[0];
-  const [selectedGroupName, setSelectedGroupName] = useState(
-    initialGroup.group.name,
-  );
+  const [selectedGroupId, setSelectedGroupId] = useState(initialGroup.group.id);
 
   const handleSelect = (id: number) => {
     router.push(`/${id}`);
@@ -37,7 +35,7 @@ export default function GroupDropdown({ memberships }: GroupDropdownProps) {
         (membership) => membership.group.id === currentGroupId,
       );
       if (currentGroup) {
-        setSelectedGroupName(currentGroup.group.name);
+        setSelectedGroupId(currentGroup.group.id);
       }
     }
   }, [currentGroupId, memberships]);
@@ -46,7 +44,12 @@ export default function GroupDropdown({ memberships }: GroupDropdownProps) {
     <div className="hidden md:block">
       <Dropdown
         selected={initialGroup.group.name}
-        setSelected={setSelectedGroupName}
+        setSelected={(name) => {
+          const selectedGroup = memberships.find(
+            (membership) => membership.group.name === name,
+          );
+          if (selectedGroup) setSelectedGroupId(selectedGroup.group.id);
+        }}
       >
         <Dropdown.Button className="gap-[11px] text-base font-medium text-text-primary">
           <Check width={16} height={16} />
@@ -58,12 +61,13 @@ export default function GroupDropdown({ memberships }: GroupDropdownProps) {
               value={membership.group.name}
             >
               <div
-                className={`flex w-full items-center justify-between rounded-lg px-2 py-[7px] hover:bg-slate-700 ${membership.group.name === selectedGroupName && "bg-slate-700"}`}
+                className={`flex w-full items-center justify-between rounded-lg px-2 py-[7px] hover:bg-slate-700 ${
+                  membership.group.id === selectedGroupId && "bg-slate-700"
+                }`}
                 onClick={() => handleSelect(membership.group.id)}
               >
                 <div className="flex items-center gap-3">
                   <div className="relative size-8 overflow-hidden rounded-md">
-                    {/* TODO - 이미지 없는 경우 기본 이미지 */}
                     <Image
                       src={membership.group.image || hamster}
                       alt={`${membership.group.name} 이미지`}
@@ -77,14 +81,16 @@ export default function GroupDropdown({ memberships }: GroupDropdownProps) {
               </div>
             </Dropdown.Item>
           ))}
-          <LinkButton
-            btnSize="large"
-            btnStyle="none_background"
-            className="mt-2"
-            href="/addteam"
-          >
-            <Plus width={16} height={16} className="mr-1" /> 팀 추가하기
-          </LinkButton>
+          <Dropdown.CloseItem>
+            <LinkButton
+              btnSize="large"
+              btnStyle="none_background"
+              className="mt-2"
+              href="/addteam"
+            >
+              <Plus width={16} height={16} className="mr-1" /> 팀 추가하기
+            </LinkButton>
+          </Dropdown.CloseItem>
         </Dropdown.Body>
       </Dropdown>
     </div>


### PR DESCRIPTION
## 🏷️ 이슈 번호 #177 

- close #177 

## 🧱 작업 사항

- 동일한 팀명 중복 스타일링 적용되는 문제 해결
- 팀 추가하기 버튼 클릭 후 드롭다운 닫히도록 수정
- 팀이 많아지는 경우를 대비해서 더보기 버튼과 숨기기 버튼을 추가했습니다. 

## 📸 결과물
팀 5개 미만인 경우 
![image](https://github.com/user-attachments/assets/fe14a90e-11f9-4f69-8dd3-0e1f2284f526)

팀 5개 이상인 경우
![image](https://github.com/user-attachments/assets/cc5df003-a284-432c-a004-4c76eebfef60)

추가로 보여줄 팀 없는 경우 숨기기 버튼 (클릭 시 4개만 보여짐) 
![image](https://github.com/user-attachments/assets/8f673e5a-8464-4725-9157-76414fc66991)


## 💬 공유 포인트 및 논의 사항
