### PR TITLE
fix: UI 개선 

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -14,7 +14,7 @@
     --text-default: #64748b;
     --text-inverse: #ffffff;
     --text-disabled: #94a3b8;
-    --border-primary: 168 25% 8%;
+    --border-primary: 12 24 20;
     --point-whiteGreen: #43c694;
     --point-grayGreen: #43c694;
   }
@@ -30,7 +30,7 @@
     --text-default: #64748b;
     --text-inverse: #ffffff;
     --text-disabled: #94a3b8;
-    --border-primary: 210 28% 98% 0.1;
+    --border-primary: 248 250 252;
     --point-whiteGreen: #ffffff;
     --point-grayGreen: #475569;
   }

--- a/components/header/LoggedIn-header-content.tsx
+++ b/components/header/LoggedIn-header-content.tsx
@@ -63,7 +63,7 @@ export default function LoggedInHeaderContent() {
           자유게시판
         </Link>
       </div>
-      <div className="flex items-center gap-4">
+      <div className="flex items-center justify-center gap-4">
         <ThemeToggle />
         <PopoverTrigger nickname={nickname} image={image} />
       </div>

--- a/components/header/popover-trigger.tsx
+++ b/components/header/popover-trigger.tsx
@@ -50,6 +50,7 @@ export default function PopoverTrigger({
         triggerText={nickname}
         triggerClassName="text-sm font-medium text-text-primary"
         contentClassName="z-10 border-[1px] bg-background-secondary border-border-primary/10 w-[120px] h-[160px] text-text-primary text-sm font-normal mt-3 md:w-[135px] md:h-[184px] md:text-base"
+        className="flex items-center"
       />
     </div>
   );

--- a/components/input-field/basic-input.tsx
+++ b/components/input-field/basic-input.tsx
@@ -49,7 +49,7 @@ export function BasicInput<TFormInput extends FieldValues>({
         </label>
       )}
       <input
-        className={`w-full rounded-xl border border-border-primary border-opacity-10 bg-background-secondary px-4 py-[13.5px] text-base font-normal text-text-primary placeholder:text-sm placeholder:font-normal placeholder:text-text-default focus:border-2 focus:outline-none disabled:cursor-not-allowed disabled:bg-background-tertiary disabled:text-text-disabled ${error ? "focus:border-status-danger" : "focus:border-interaction-focus"} ${className}`}
+        className={`w-full rounded-xl border border-border-primary/10 bg-background-secondary px-4 py-[13.5px] text-base font-normal text-text-primary placeholder:text-sm placeholder:font-normal placeholder:text-text-default focus:border-2 focus:outline-none disabled:cursor-not-allowed disabled:bg-background-tertiary disabled:text-text-disabled ${error ? "focus:border-status-danger" : "focus:border-interaction-focus"} ${className}`}
         {...register(id)}
         {...rest}
         id={id}

--- a/components/landing/footer.tsx
+++ b/components/landing/footer.tsx
@@ -3,7 +3,7 @@ import Image from "next/image";
 
 export default function Footer() {
   return (
-    <footer className="relative mt-[123px] h-[517px] w-full">
+    <footer className="relative mt-[123px] h-[517px] w-full xl:mx-auto xl:max-w-[1920px]">
       <div className="flex flex-col items-center justify-center gap-4">
         <h2 className="text-2xl font-semibold text-text-primary md:text-[40px]">
           지금 바로 시작해보세요

--- a/components/landing/landing-header.tsx
+++ b/components/landing/landing-header.tsx
@@ -10,7 +10,7 @@ export default function LandingHeader() {
   const isLoggedIn = hasCookie("refreshToken", { cookies });
 
   return (
-    <section className="relative h-[547px] w-full">
+    <section className="relative h-[547px] w-full xl:mx-auto xl:max-w-[1920px]">
       <Image
         src={header}
         fill

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -62,8 +62,7 @@ const config: Config = {
           focus: "#10B981",
         },
         border: {
-          primary: "#F8FAFC",
-          // primary: "hsl(var(--border-primary) / <alpha-value>)",
+          primary: "rgb(var(--border-primary) / <alpha-value>)",
         },
         text: {
           primary: "var(--text-primary)",
@@ -88,7 +87,6 @@ const config: Config = {
           "conic-gradient(from 180deg at 50% 50%, var(--tw-gradient-stops))",
         gradient: "linear-gradient(to right, #10B981, #A3E635)",
       },
-
       fontFamily: { Pretendard: ["Pretendard", "ui-sans-serif", "system-ui"] },
     },
   },


### PR DESCRIPTION
## 🏷️ 이슈 번호 #243 

- close #243 

## 🧱 작업 사항
- 랜딩 헤더,푸터 이미지 잘리는 문제 해결 
- 헤더 x 축 정렬 
- border-primary css 변수 적용

## 📸 결과물
![image](https://github.com/user-attachments/assets/2d40207a-cf1e-44e0-b938-85b24b7d6560)
![image](https://github.com/user-attachments/assets/e621a89c-cda5-4e9a-a0ba-70d0d73bcb2e)


## 💬 공유 포인트 및 논의 사항
- border-primary css 변수 적용하면 ` border-border-primary border-opacity-10` 이렇게 투명도 조절하는 방식이 안 되더라구요 이유를 넘 알고 싶은데 못 찾았어요 ..ㅠㅠ  
- `border-border-primary/10` 이런 식으로 투명도 조절해 주셔야 합니다. 
