### PR TITLE
fix: default 이미지 적용이 안되는 문제

### DIFF
--- a/components/profile-Icon/profile-icon.tsx
+++ b/components/profile-Icon/profile-icon.tsx
@@ -4,7 +4,7 @@ import React from "react";
 interface ProfileIconProps {
   width: number;
   height: number;
-  image: string | null;
+  image: string;
   type: "teamProfile" | "myProfile";
 }
 
@@ -28,7 +28,7 @@ export default function ProfileIcon({
           width={width}
           height={height}
           className="rounded-full"
-          src={image ?? "/icons/img.svg"}
+          src={image || "/icons/img.svg"}
           alt="팀이미지"
         />
       )}
@@ -38,7 +38,7 @@ export default function ProfileIcon({
           className="rounded-full"
           width={width}
           height={height}
-          src={image ?? "/icons/my-profile.svg"}
+          src={image || "/icons/default-profile.svg"}
           alt="나의이미지"
         />
       )}

--- a/components/profile-Icon/profile-icon.tsx
+++ b/components/profile-Icon/profile-icon.tsx
@@ -4,7 +4,7 @@ import React from "react";
 interface ProfileIconProps {
   width: number;
   height: number;
-  image: string;
+  image: string | null;
   type: "teamProfile" | "myProfile";
 }
 


### PR DESCRIPTION
<!-- PR 제목은 커밋 메세지 컨벤션 형식으로 작성 -->

## 🏷️ 이슈 번호 <!-- 이슈 번호 입력 -->

- close #253

## 🧱 작업 사항
1.기존에 api에서 이미지의 없다는 의미를 null로 사용하여  Nullish Coalescing 을 사용하였지만 api 변경에 따른 이미지가 없다는 빈 문자열로 변경되어 or 연산자를 사용하여 빈문자열도 대응되도록 변경 하였습니다. 


## 📸 결과물
<img width="1680" alt="image" src="https://github.com/user-attachments/assets/edaba6b7-8c02-4ea9-9dd1-ca157c1fe689">
## 💬 공유 포인트 및 논의 사항
