### PR TITLE
fix: 팀명 설정 아이콘 안 눌리는 버그 수정

### DIFF
--- a/app/[groupId]/_components/team-name.tsx
+++ b/app/[groupId]/_components/team-name.tsx
@@ -48,6 +48,7 @@ function TeamName({ groupId, isAdmin }: TeamNameProps) {
               },
               { text: "삭제하기", onClick: ModalTeamDeleteOverlay.open },
             ]}
+            className="z-[1]"
             contentClassName="z-10 border-[1px] absolute right-0 bg-background-secondary border-border-primary/10 w-[120px] h-[80px] text-text-secondary"
           />
         )}


### PR DESCRIPTION
<!-- PR 제목은 커밋 메세지 컨벤션 형식으로 작성 -->

## 🏷️ 이슈 번호 #260 

- close #260 

## 🧱 작업 사항
z-index 때문에 밀려나서 설정 아이콘이 안 눌려서 수정했습니다.

## 📸 결과물

## 💬 공유 포인트 및 논의 사항
