### PR TITLE
refactor: 팀 참여하기, 탈퇴하기 로직 수정

### DIFF
--- a/app/(team-setting)/participate-team/_components/participate-team-form.tsx
+++ b/app/(team-setting)/participate-team/_components/participate-team-form.tsx
@@ -4,7 +4,8 @@ import Button from "@/components/button/button";
 import { BasicInput } from "@/components/input-field/basic-input";
 import { postGroupInvitation } from "@/lib/apis/group";
 import { showToast } from "@/lib/show-toast";
-import { useRouter, useSearchParams } from "next/navigation";
+import { useRouter } from "next-nprogress-bar";
+import { useSearchParams } from "next/navigation";
 import { useForm } from "react-hook-form";
 
 interface ParticipateTeamFormProps {
@@ -27,13 +28,16 @@ function ParticipateTeamForm({ email }: ParticipateTeamFormProps) {
 
   const onSubmit = async (data: TeamLinkFormValues) => {
     try {
-      await postGroupInvitation({
+      const response = await postGroupInvitation({
         userEmail: email,
         token: data.token,
       });
-      showToast("success", "팀 참여에 성공하였습니다.");
-      router.push("/");
-      router.refresh();
+      if (response) {
+        showToast("success", "팀 참여에 성공하였습니다.");
+        router.push(`/${response.groupId}`);
+      } else {
+        router.push("/");
+      }
     } catch (error) {
       showToast(
         "error",

--- a/app/[groupId]/_components/member-list.tsx
+++ b/app/[groupId]/_components/member-list.tsx
@@ -4,6 +4,7 @@ import Popover from "@/components/popover/popover";
 import { useCustomOverlay } from "@/hooks/use-custom-overlay";
 import { getGroupInfo } from "@/lib/apis/group/index";
 import { GetGroupsIdResponse } from "@/lib/apis/type";
+import { getUser } from "@/lib/apis/user";
 import Crown from "@/public/icons/crown.png";
 import DefaultProfile from "@/public/icons/default-profile.svg";
 import Kebab from "@/public/icons/kebab-small.svg";
@@ -46,6 +47,9 @@ function MemberCard({ member, groupId, isAdmin }: MemberCardProps) {
     />
   ));
 
+  const { data } = useQuery({ queryKey: ["getUser"], queryFn: getUser });
+  const myId = data ? data.id : "";
+
   return (
     <div
       role="presentation"
@@ -77,7 +81,7 @@ function MemberCard({ member, groupId, isAdmin }: MemberCardProps) {
           {member.userEmail}
         </p>
       </div>
-      {isAdmin && (
+      {(isAdmin || myId === member.userId) && (
         <button
           aria-label="팝오버"
           type="submit"

--- a/app/[groupId]/_components/member-list.tsx
+++ b/app/[groupId]/_components/member-list.tsx
@@ -21,6 +21,7 @@ interface MemberCardProps {
   member: MemberType;
   groupId: string;
   isAdmin: boolean;
+  teamName: string;
 }
 
 interface MemberListProps {
@@ -28,7 +29,7 @@ interface MemberListProps {
   isAdmin: boolean;
 }
 
-function MemberCard({ member, groupId, isAdmin }: MemberCardProps) {
+function MemberCard({ member, groupId, isAdmin, teamName }: MemberCardProps) {
   const ModalMemberProfileOverlay = useCustomOverlay(({ close }) => (
     <ModalMemberProfile
       close={close}
@@ -44,6 +45,7 @@ function MemberCard({ member, groupId, isAdmin }: MemberCardProps) {
       groupId={groupId}
       memberUserId={member.userId}
       userName={member.userName}
+      teamName={teamName}
     />
   ));
 
@@ -94,7 +96,10 @@ function MemberCard({ member, groupId, isAdmin }: MemberCardProps) {
             triggerHeight={16}
             triggerWidth={16}
             content={[
-              { text: "삭제하기", onClick: ModalMemberDeleteOverlay.open },
+              {
+                text: myId === member.userId ? "탈퇴하기" : "삭제하기",
+                onClick: ModalMemberDeleteOverlay.open,
+              },
             ]}
             contentClassName="z-10 border-[1px] absolute right-0 bg-background-secondary border-border-primary/10 w-[120px] h-[40px] text-text-secondary"
           />
@@ -110,6 +115,7 @@ function MemberList({ groupId, isAdmin }: MemberListProps) {
     queryFn: () => getGroupInfo({ groupId }),
   });
 
+  const teamName = data ? data.name : "";
   const members = data ? data.members : [];
 
   const ModalMemberAddOverlay = useCustomOverlay(({ close }) => (
@@ -143,6 +149,7 @@ function MemberList({ groupId, isAdmin }: MemberListProps) {
               isAdmin={isAdmin}
               member={member}
               groupId={groupId}
+              teamName={teamName}
             />
           ))
         ) : (

--- a/app/[groupId]/_components/modal/modal-member-delete.tsx
+++ b/app/[groupId]/_components/modal/modal-member-delete.tsx
@@ -3,15 +3,18 @@
 import Modal from "@/components/modal/modal";
 import { deleteTeamMember } from "@/lib/apis/group";
 import { GetGroupsIdResponse } from "@/lib/apis/type";
+import { getUser } from "@/lib/apis/user";
 import { showToast } from "@/lib/show-toast";
 import AlertIcon from "@/public/icons/alert.svg";
-import { useMutation, useQueryClient } from "@tanstack/react-query";
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+import { useRouter } from "next-nprogress-bar";
 
 interface ModalMemberDeleteProps {
   close: () => void;
   groupId: string;
   memberUserId: number;
   userName: string;
+  teamName: string;
 }
 
 function ModalMemberDelete({
@@ -19,8 +22,13 @@ function ModalMemberDelete({
   groupId,
   memberUserId,
   userName,
+  teamName,
 }: ModalMemberDeleteProps) {
+  const router = useRouter();
   const queryClient = useQueryClient();
+  const { data } = useQuery({ queryKey: ["getUser"], queryFn: getUser });
+  const isMine = data?.id === memberUserId;
+  const buttonMessage = isMine ? "탈퇴" : "삭제";
 
   const deleteMemberMutation = useMutation({
     mutationFn: () => deleteTeamMember({ groupId, memberUserId }),
@@ -45,16 +53,27 @@ function ModalMemberDelete({
     // eslint-disable-next-line
     onError: (error, memberUserId, context) => {
       queryClient.setQueryData(["groupInfo"], context?.previousData);
-      showToast(
-        "error",
-        error instanceof Error
-          ? error.message
-          : `${userName}님 삭제에 실패하였습니다.`,
-      );
+      let message;
+      if (error instanceof Error) {
+        message = error.message;
+      } else if (isMine) {
+        message = `${teamName}팀 탈퇴에 실패하였습니다.`;
+      } else {
+        message = `${userName}님 삭제에 실패하였습니다.`;
+      }
+      showToast("error", message);
     },
     onSuccess: () => {
-      showToast("success", `${userName}님이 삭제되었습니다.`);
+      showToast(
+        "success",
+        isMine
+          ? `${teamName}팀에서 탈퇴하였습니다.`
+          : `${userName}님이 삭제되었습니다.`,
+      );
       close();
+      if (isMine) {
+        router.push("/");
+      }
     },
     onSettled: () => {
       queryClient.invalidateQueries({ queryKey: ["groupInfo"] });
@@ -70,7 +89,11 @@ function ModalMemberDelete({
       <div className="flex h-[173px] flex-col items-center justify-center gap-[24px]">
         <div className="flex flex-col items-center gap-[16px]">
           <AlertIcon width={24} height={24} />
-          <Modal.Title>{userName}님을 삭제하시겠어요?</Modal.Title>
+          {isMine ? (
+            <Modal.Title>{teamName}팀에서 탈퇴하시겠습니까?</Modal.Title>
+          ) : (
+            <Modal.Title>{userName}님을 삭제하시겠어요?</Modal.Title>
+          )}
         </div>
 
         <div className="w-[280px]">
@@ -78,7 +101,9 @@ function ModalMemberDelete({
             closeBtnStyle="outlined_secondary"
             confirmBtnStyle="danger"
             buttonDescription={
-              deleteMemberMutation.isPending ? "삭제 중..." : "삭제하기"
+              deleteMemberMutation.isPending
+                ? `${buttonMessage} 중...`
+                : `${buttonMessage}하기`
             }
             disabled={deleteMemberMutation.isPending}
             close={close}

--- a/app/[groupId]/_components/modal/modal-member-delete.tsx
+++ b/app/[groupId]/_components/modal/modal-member-delete.tsx
@@ -57,7 +57,7 @@ function ModalMemberDelete({
       if (error instanceof Error) {
         message = error.message;
       } else if (isMine) {
-        message = `${teamName}팀 탈퇴에 실패하였습니다.`;
+        message = `${teamName} 탈퇴에 실패하였습니다.`;
       } else {
         message = `${userName}님 삭제에 실패하였습니다.`;
       }
@@ -67,7 +67,7 @@ function ModalMemberDelete({
       showToast(
         "success",
         isMine
-          ? `${teamName}팀에서 탈퇴하였습니다.`
+          ? `${teamName}에서 탈퇴하였습니다.`
           : `${userName}님이 삭제되었습니다.`,
       );
       close();
@@ -90,7 +90,7 @@ function ModalMemberDelete({
         <div className="flex flex-col items-center gap-[16px]">
           <AlertIcon width={24} height={24} />
           {isMine ? (
-            <Modal.Title>{teamName}팀에서 탈퇴하시겠습니까?</Modal.Title>
+            <Modal.Title>{teamName}에서 탈퇴하시겠습니까?</Modal.Title>
           ) : (
             <Modal.Title>{userName}님을 삭제하시겠어요?</Modal.Title>
           )}

--- a/lib/apis/type/index.ts
+++ b/lib/apis/type/index.ts
@@ -250,7 +250,9 @@ export type GetGroupsIdMemberMemberUserIdResponse = {
 
 export type DeleteGroupsIdMemberMemberUserIdResponse = {};
 
-export type GetGroupsIdInvitationResponse = string;
+export type GetGroupsIdInvitationResponse = {
+  groupId: number;
+};
 
 export type PostGroupsAcceptInvitationResponse = {
   userId: number;


### PR DESCRIPTION
<!-- PR 제목은 커밋 메세지 컨벤션 형식으로 작성 -->

## 🏷️ 이슈 번호 #240

- close #240

## 🧱 작업 사항
- 팀 참여 후 해당 팀 페이지로 이동하도록 수정하였습니다.
- 기존에는 멤버 삭제 기능이 admin에게만 주어졌는데, 본인의 경우에는 스스로 팀에서 탈퇴할 수 있도록 수정하였습니다.


## 📸 결과물
<img width="400" alt="image" src="https://github.com/user-attachments/assets/b3427b93-b3ad-4e7c-9ad7-49797e18a737">


## 💬 공유 포인트 및 논의 사항
- 케밥 클릭했을 때 MemberCard 자체에 active 효과 들어가는 건........ 일단 제 머리론 안 되네요..... group, peer 다 시도는 해보았습니다......
