### PR TITLE
refactor: 할 일 목록 클릭 시, 할 일 목록 id를 query로 전달 / admin 왕관 달아주기

### DIFF
--- a/app/[groupId]/_components/member-list.tsx
+++ b/app/[groupId]/_components/member-list.tsx
@@ -36,6 +36,7 @@ function MemberCard({ member, groupId, isAdmin, teamName }: MemberCardProps) {
       userImage={member.userImage}
       userName={member.userName}
       userEmail={member.userEmail}
+      isAdmin={isAdmin}
     />
   ));
 

--- a/app/[groupId]/_components/modal/modal-member-profile.tsx
+++ b/app/[groupId]/_components/modal/modal-member-profile.tsx
@@ -1,6 +1,7 @@
 import Button from "@/components/button/button";
 import Modal from "@/components/modal/modal";
 import { showToast } from "@/lib/show-toast";
+import Crown from "@/public/icons/crown.png";
 import DefaultProfile from "@/public/icons/default-profile.svg";
 import XIcon from "@/public/icons/x.svg";
 import Image from "next/image";
@@ -10,6 +11,7 @@ interface ModalMemberProfileProps {
   userImage: string;
   userName: string;
   userEmail: string;
+  isAdmin: boolean;
 }
 
 function ModalMemberProfile({
@@ -17,6 +19,7 @@ function ModalMemberProfile({
   userImage,
   userName,
   userEmail,
+  isAdmin,
 }: ModalMemberProfileProps) {
   const handleButtonClick = async () => {
     try {
@@ -55,9 +58,16 @@ function ModalMemberProfile({
             )}
 
             <div className="flex flex-col items-center justify-center gap-[8px]">
-              <p className="text-[14px] font-[500] text-text-primary">
-                {userName}
-              </p>
+              <div className="flex items-center gap-[4px]">
+                {isAdmin && (
+                  <Image src={Crown} alt="왕관" width={20} height={20} />
+                )}
+
+                <p className="text-[14px] font-[500] text-text-primary">
+                  {userName}
+                </p>
+              </div>
+
               <p className="text-[12px] font-[400] text-text-secondary">
                 {userEmail}
               </p>

--- a/app/[groupId]/_components/task-lists.tsx
+++ b/app/[groupId]/_components/task-lists.tsx
@@ -70,7 +70,7 @@ function TaskList({ taskList, groupId, index }: TaskListProps) {
   return (
     <div
       role="presentation"
-      onClick={() => router.push(`/${groupId}/tasks`)}
+      onClick={() => router.push(`/${groupId}/tasks?id=${taskList.id}`)}
       className="flex h-[40px] cursor-pointer items-center justify-between rounded-[12px] bg-background-secondary text-[14px] font-[500] leading-[40px] text-text-primary hover:bg-background-tertiary hover:shadow-lg active:bg-background-tertiary active:shadow-lg"
     >
       <div className="flex gap-[12px]">


### PR DESCRIPTION
<!-- PR 제목은 커밋 메세지 컨벤션 형식으로 작성 -->

## 🏷️ 이슈 번호 #280

- close #280 

## 🧱 작업 사항
- 기존에는 할 일 목록 클릭 시, groupId/tasks로 이동하도록 하였는데, 이제는 할 일 목록을 클릭하면 해당 할 일 목록의 task 페이지로 이동할 수 있도록 query를 전달합니다.
- 멤버 프로필 모달에서도 admin에게는 왕관을 달아주었습니다.

## 📸 결과물
<img width="418" alt="스크린샷 2024-08-27 오후 5 02 32" src="https://github.com/user-attachments/assets/aa8cd363-7efa-4089-870e-24b9b3c02a70">


## 💬 공유 포인트 및 논의 사항
