### PR TITLE
refactor: task페이지 스크롤 굵기 수정

### DIFF
--- a/app/[groupId]/tasks/_components/no-items/no-list.tsx
+++ b/app/[groupId]/tasks/_components/no-items/no-list.tsx
@@ -2,7 +2,7 @@ import React from "react";
 
 export default function NoList() {
   return (
-    <p className="mx-auto mt-[30vh] h-[34px] w-[156px] text-text-default">
+    <p className="mx-auto mt-[30vh] h-[34px] text-center text-text-default">
       아직 할일 목록이 없습니다.
       <br />
       새로운 목록을 추가해보세요.

--- a/app/[groupId]/tasks/_components/no-items/no-todo.tsx
+++ b/app/[groupId]/tasks/_components/no-items/no-todo.tsx
@@ -2,8 +2,8 @@ import React from "react";
 
 export default function NoTodo() {
   return (
-    <p className="mx-auto mt-[30vh] h-[34px] w-[156px] self-center text-text-default">
-      아직 할 일이 목록이없습니다.
+    <p className="mx-auto mt-[30vh] h-[34px] text-center text-text-default">
+      아직 할 일이 없습니다.
       <br />할 일을 추가해보세요.
     </p>
   );

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -98,6 +98,7 @@ const config: Config = {
         "*": {
           "&::-webkit-scrollbar": {
             width: "7px",
+            height: "7px",
           },
           "&::-webkit-scrollbar-thumb": {
             backgroundColor: "var(--point-whiteGreen)",

--- a/utils/convert-date.ts
+++ b/utils/convert-date.ts
@@ -21,7 +21,7 @@ export const covertDate = (date: Date) => {
   const day = date.getDate();
   const dayOfWeek = date.getDay();
 
-  return `${month}월 ${day}일${dayNames[dayOfWeek]}요일`;
+  return `${month}월 ${day}일 ${dayNames[dayOfWeek]}요일`;
 };
 
 export const convertDateToY_M_D = (date: Date) => {


### PR DESCRIPTION
<!-- PR 제목은 커밋 메세지 컨벤션 형식으로 작성 -->

## 🏷️ 이슈 번호 #290

- close #290

## 🧱 작업 사항
- task 페이지의 가로 스크롤 굵기를 수정하였습니다.
    - 처음엔 더 얇은 스크롤을 하나 더 만들었는데 그럴 필요가 없었어요! 여기는 가로 스크롤이라 height로 굵기를 조절해야 하는데 기존에는 width만 지정해둔 상태라 height만 추가해줬습니다~.
- 요일과 날짜 사이에 띄어쓰기를 추가하였습니다.
- 할 일 목록, 할 일이 없을 때 문구를 수정하였습니다.

## 📸 결과물
<img width="495" alt="image" src="https://github.com/user-attachments/assets/477c5645-d6c6-4eb1-af61-e6324aae3de7">
<img width="495" alt="image" src="https://github.com/user-attachments/assets/e571f12d-1efb-484a-a845-5fa8c1fbd7ba">



## 💬 공유 포인트 및 논의 사항
