### PR TITLE
fix: http를 https로 변환하는 커스텀 로더 추가

### DIFF
--- a/my/image/loader.js
+++ b/my/image/loader.js
@@ -1,0 +1,8 @@
+"use client";
+
+export default function myImageLoader({ src, width, quality }) {
+  const secureSrc = src.startsWith("http://")
+    ? src.replace("http://", "https://")
+    : src;
+  return `${secureSrc}?w=${width}&q=${quality || 75}`;
+}

--- a/next.config.mjs
+++ b/next.config.mjs
@@ -21,6 +21,8 @@ const nextConfig = {
         port: "",
       },
     ],
+    loader: "custom",
+    loaderFile: "./my/image/loader.js",
   },
   webpack: (config) => {
     config.module.rules.push({

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -30,7 +30,8 @@
     "**/*.tsx",
     ".next/types/**/*.ts",
     "app/(auth)/.gitkeep",
-    "next.config.mjs"
+    "next.config.mjs",
+    "my/image/loader.js"
   ],
   "exclude": ["node_modules"]
 }


### PR DESCRIPTION
## 🏷️ 이슈 번호 #298 

- close #298 

## 🧱 작업 사항
- 카카오 계정 이미지가 기본 이미지든 이미지가 있는 http로 되어 있어서 배포 환경에서 생기는 오류입니다. 
- https://nextjs.org/docs/app/api-reference/next-config-js/images 이거 참고해서 http를 https로 변환하게 했습니다. 로컬에서는 잘 되는데 배포에서도 한 번 확인해 봐야할 거 같아요 🫠 

## 📸 결과물

## 💬 공유 포인트 및 논의 사항
