### PR TITLE
fix: 로그인, 회원가입 로딩 처리 통일

### DIFF
--- a/app/(auth)/signup/_components/signup-form.tsx
+++ b/app/(auth)/signup/_components/signup-form.tsx
@@ -11,7 +11,6 @@ import { yupResolver } from "@hookform/resolvers/yup";
 import { useMutation } from "@tanstack/react-query";
 import { useRouter } from "next-nprogress-bar";
 import { SubmitHandler, useForm } from "react-hook-form";
-import { toast } from "react-toastify";
 
 import useAuthError from "../../_hooks/use-auth-error";
 
@@ -30,19 +29,8 @@ export default function SignUpForm() {
 
   const mutation = useMutation({
     mutationFn: (data: SignUpInputValue) => signUp(data),
-    onMutate: () => {
-      showToast("loading", "회원가입을 진행 중입니다.", {
-        toastId: "signUp",
-      });
-    },
     onSuccess: () => {
-      toast.update("signUp", {
-        render: "회원가입이 정상적으로 처리되었습니다.",
-        type: "success",
-        isLoading: false,
-        hideProgressBar: false,
-        autoClose: 1000,
-      });
+      showToast("success", "회원가입이 정상적으로 처리되었습니다.");
       router.push("/login");
     },
     onError: handleError,
@@ -92,7 +80,7 @@ export default function SignUpForm() {
         className="mb-[25px] mt-10 w-full"
         disabled={!isValid || mutation.isPending}
       >
-        회원가입
+        {mutation.isPending ? "회원가입 중" : "회원가입"}
       </Button>
     </form>
   );


### PR DESCRIPTION
## 🏷️ 이슈 번호 #300 

- close #300 

## 🧱 작업 사항
- 로그인과 회원가입의 로딩 처리를 동일하게 변경하였습니다. 
- 회원가입 성공 시에만 성공 토스트를 띄웁니다. 

## 📸 결과물

## 💬 공유 포인트 및 논의 사항
