### PR TITLE
fix:utc 시간 설정 문제

### DIFF
--- a/app/[groupId]/tasks/_components/comment/comment.tsx
+++ b/app/[groupId]/tasks/_components/comment/comment.tsx
@@ -95,7 +95,7 @@ function Comment({ date, taskListId, commentData }: CommentProps) {
           {!isEidtMode && (
             <CommentKebabPopOver
               userId={userData?.id}
-              commentUserId={commentData.id}
+              commentUserId={commentData.userId}
               handleClickDeleteComment={handleClickDeleteComment}
               handleClickEditMode={handleClickEditMode}
             />

--- a/app/[groupId]/tasks/_components/modal/add-todo-modal/index.tsx
+++ b/app/[groupId]/tasks/_components/modal/add-todo-modal/index.tsx
@@ -61,12 +61,14 @@ function AddTodoModal({ groupId, taskListId, date, close }: AddTodoModalProps) {
       if (data.frequencyType === "MONTHLY") {
         const { weekDays, startDate, ...newData } = data;
 
-        mutate({ ...newData, startDate: startDate.toISOString() });
+        mutate({ ...newData });
       } else if (data.frequencyType === "WEEKLY") {
         const { monthDay, startDate, ...newData } = data;
-        mutate({ ...newData, startDate: startDate.toISOString() });
+
+        mutate({ ...newData });
       } else {
         const { monthDay, weekDays, startDate, ...newData } = data;
+        startDate.setHours(startDate.getHours() + 9);
         mutate({ ...newData, startDate: startDate.toISOString() });
       }
     }

--- a/app/[groupId]/tasks/_components/modal/add-todo-modal/index.tsx
+++ b/app/[groupId]/tasks/_components/modal/add-todo-modal/index.tsx
@@ -59,14 +59,15 @@ function AddTodoModal({ groupId, taskListId, date, close }: AddTodoModalProps) {
   const serveData = (data: TodoFormType) => {
     if (taskListId !== -1) {
       if (data.frequencyType === "MONTHLY") {
-        const { weekDays, ...newData } = data;
-        mutate(newData);
+        const { weekDays, startDate, ...newData } = data;
+
+        mutate({ ...newData, startDate: startDate.toISOString() });
       } else if (data.frequencyType === "WEEKLY") {
-        const { monthDay, ...newData } = data;
-        mutate(newData);
+        const { monthDay, startDate, ...newData } = data;
+        mutate({ ...newData, startDate: startDate.toISOString() });
       } else {
-        const { monthDay, weekDays, ...newData } = data;
-        mutate(newData);
+        const { monthDay, weekDays, startDate, ...newData } = data;
+        mutate({ ...newData, startDate: startDate.toISOString() });
       }
     }
   };

--- a/app/[groupId]/tasks/_components/side-bar.tsx
+++ b/app/[groupId]/tasks/_components/side-bar.tsx
@@ -112,7 +112,7 @@ export default function SideBar({
               </h1>
 
               <KebabPopover
-                commentUserId={taskDetail?.writer.id}
+                todoUserId={taskDetail?.writer.id}
                 openDeleteModal={deleteTodoModalOverlay.open}
                 openEditModal={editTodoModalOverlay.open}
               />

--- a/app/[groupId]/tasks/_components/side-bar.tsx
+++ b/app/[groupId]/tasks/_components/side-bar.tsx
@@ -9,7 +9,7 @@ import Time from "@/public/icons/time.svg";
 import { checkTodo } from "@/utils/checkTodo";
 import { convertDateToTime, convertDateToYMD } from "@/utils/convert-date";
 import { covertFrequency } from "@/utils/convert-frequency";
-import React from "react";
+import React, { useMemo } from "react";
 
 import Comment from "./comment/comment";
 import CommentInput from "./comment/comment-input";
@@ -84,6 +84,8 @@ export default function SideBar({
   const { ampm, hoursString, minutesString } = convertDateToTime(
     new Date(taskDetail?.date ?? ""),
   );
+
+  useMemo(() => comment?.sort((a, b) => a.id - b.id), [comment]);
 
   return (
     <div

--- a/app/[groupId]/tasks/_components/todo/kebab-popover.tsx
+++ b/app/[groupId]/tasks/_components/todo/kebab-popover.tsx
@@ -5,7 +5,7 @@ import { useQuery } from "@tanstack/react-query";
 import React from "react";
 
 interface KebabPopoverProps {
-  commentUserId?: number;
+  todoUserId?: number;
   openEditModal: () => void;
   openDeleteModal: () => void;
 }
@@ -14,7 +14,7 @@ function KebabPopover({
   openEditModal,
   openDeleteModal,
 
-  commentUserId,
+  todoUserId,
 }: KebabPopoverProps) {
   const { data: user } = useQuery({ queryKey: ["getUser"], queryFn: getUser });
   const constent = [
@@ -32,7 +32,7 @@ function KebabPopover({
       triggerHeight={16}
       content={constent}
       className=""
-      contentClassName={`h-[80px] w-[120px] bg-background-secondary !border border-background-tertiary text-text-primary ${user?.id !== commentUserId && "hidden"}`}
+      contentClassName={`h-[80px] w-[120px] bg-background-secondary !border border-background-tertiary text-text-primary ${user?.id !== todoUserId && "hidden"}`}
     />
   );
 }

--- a/app/[groupId]/tasks/_components/todo/todo-box.tsx
+++ b/app/[groupId]/tasks/_components/todo/todo-box.tsx
@@ -14,6 +14,7 @@ import EditTodoModal from "../modal/edit-todo-modal";
 import KebabPopover from "./kebab-popover";
 
 interface TodoBoxProps {
+  userId: number;
   frequency: "ONCE" | "DAILY" | "WEEKLY" | "MONTHLY";
   groupId: string;
   taskListId: number | undefined;
@@ -29,6 +30,7 @@ interface TodoBoxProps {
 }
 
 function TodoBox({
+  userId,
   groupId,
   taskListId,
   id,
@@ -98,6 +100,7 @@ function TodoBox({
           </div>
         </div>
         <KebabPopover
+          commentUserId={userId}
           openEditModal={editTodoModalOverlay.open}
           openDeleteModal={deleteTodoModalOverlay.open}
         />

--- a/app/[groupId]/tasks/_components/todo/todo-box.tsx
+++ b/app/[groupId]/tasks/_components/todo/todo-box.tsx
@@ -100,7 +100,7 @@ function TodoBox({
           </div>
         </div>
         <KebabPopover
-          commentUserId={userId}
+          todoUserId={userId}
           openEditModal={editTodoModalOverlay.open}
           openDeleteModal={deleteTodoModalOverlay.open}
         />

--- a/app/[groupId]/tasks/_components/todo/todo-contents.tsx
+++ b/app/[groupId]/tasks/_components/todo/todo-contents.tsx
@@ -59,6 +59,7 @@ function TodoContents({ taskLists, date, groupId }: TodoContentsProps) {
           tasks &&
           tasks.map((e) => (
             <TodoBox
+              userId={e.writer.id}
               key={e.id}
               groupId={groupId}
               taskListId={selectedButton}

--- a/app/[groupId]/tasks/_hooks/use-calendar.ts
+++ b/app/[groupId]/tasks/_hooks/use-calendar.ts
@@ -3,6 +3,7 @@ import React, { useState } from "react";
 
 const useCalender = () => {
   const [date, setDate] = useState<Date>(new Date());
+
   const convertedDate = covertDate(date);
   const handleChangeDate = (newDate: Date | null) => {
     if (newDate) {

--- a/lib/apis/task/hooks/use-post-task.ts
+++ b/lib/apis/task/hooks/use-post-task.ts
@@ -5,7 +5,7 @@ import { postTask } from "..";
 interface TodoFormType {
   name: string;
   description: string;
-  startDate: string;
+  startDate?: string;
   frequencyType: "ONCE" | "DAILY" | "WEEKLY" | "MONTHLY";
   monthDay?: number;
   weekDays?: number[];

--- a/lib/apis/task/hooks/use-post-task.ts
+++ b/lib/apis/task/hooks/use-post-task.ts
@@ -5,7 +5,7 @@ import { postTask } from "..";
 interface TodoFormType {
   name: string;
   description: string;
-  startDate: Date;
+  startDate: string;
   frequencyType: "ONCE" | "DAILY" | "WEEKLY" | "MONTHLY";
   monthDay?: number;
   weekDays?: number[];

--- a/lib/apis/task/index.ts
+++ b/lib/apis/task/index.ts
@@ -1,5 +1,3 @@
-import { convertDateToY_M_D } from "@/utils/convert-date";
-
 import { myFetch } from "../myFetch";
 import { GetTaskResponse, GetTasksResponse } from "./type";
 
@@ -11,7 +9,7 @@ export const postTask = async (
   data: {
     name: string;
     description: string;
-    startDate: Date;
+    startDate: string;
     frequencyType: "ONCE" | "DAILY" | "WEEKLY" | "MONTHLY";
     monthDay?: number;
     weekDays?: number[];
@@ -37,9 +35,11 @@ export const getTasks = async (
   taskListId: number | undefined,
   date?: Date,
 ): Promise<GetTasksResponse> => {
+  console.log(date?.toString());
+
   try {
     const response = await myFetch<GetTasksResponse>(
-      `${URL}/groups/${groupId}/task-lists/${taskListId}/tasks?date=${date?.toLocaleDateString()}`,
+      `${URL}/groups/${groupId}/task-lists/${taskListId}/tasks?date=${date}`,
       {
         method: "GET",
         headers: {

--- a/lib/apis/task/index.ts
+++ b/lib/apis/task/index.ts
@@ -9,7 +9,7 @@ export const postTask = async (
   data: {
     name: string;
     description: string;
-    startDate: string;
+    startDate?: string;
     frequencyType: "ONCE" | "DAILY" | "WEEKLY" | "MONTHLY";
     monthDay?: number;
     weekDays?: number[];
@@ -35,8 +35,6 @@ export const getTasks = async (
   taskListId: number | undefined,
   date?: Date,
 ): Promise<GetTasksResponse> => {
-  console.log(date?.toString());
-
   try {
     const response = await myFetch<GetTasksResponse>(
       `${URL}/groups/${groupId}/task-lists/${taskListId}/tasks?date=${date}`,

--- a/lib/apis/task/index.ts
+++ b/lib/apis/task/index.ts
@@ -37,10 +37,9 @@ export const getTasks = async (
   taskListId: number | undefined,
   date?: Date,
 ): Promise<GetTasksResponse> => {
-  const convertedDateToYMD = convertDateToY_M_D(date ?? new Date());
   try {
     const response = await myFetch<GetTasksResponse>(
-      `${URL}/groups/${groupId}/task-lists/${taskListId}/tasks?date=${convertedDateToYMD}`,
+      `${URL}/groups/${groupId}/task-lists/${taskListId}/tasks?date=${date?.toLocaleDateString()}`,
       {
         method: "GET",
         headers: {


### PR DESCRIPTION
<!-- PR 제목은 커밋 메세지 컨벤션 형식으로 작성 -->

## 🏷️ 이슈 번호 <!-- 이슈 번호 입력 -->

- close #304 

## 🧱 작업 사항
1. utc시간애다 9시간 더하여 한국시간이 되도록 task를 보내는 요청을 수정했습니다. 
2. tobox의 팝오버가 열리는 로직이 누락되어 수정했습니다.
3. 댓글의 팝오버 열리는 로직이 누락되어 수정했습니다.
4. 댓글 배열이 기본적으로 id값으로 나열될줄알았는데 sort를 한번해줘서 수정했습니다.
## 📸 결과물
![Pasted Graphic](https://github.com/user-attachments/assets/06cb1892-d733-4957-ba76-719a2be0ff7c)


## 💬 공유 포인트 및 논의 사항
