### PR TITLE
fix: 모든 멤버의 프로필 모달에 왕관 달아주는 버그 수정

### DIFF
--- a/app/[groupId]/_components/member-list.tsx
+++ b/app/[groupId]/_components/member-list.tsx
@@ -36,7 +36,7 @@ function MemberCard({ member, groupId, isAdmin, teamName }: MemberCardProps) {
       userImage={member.userImage}
       userName={member.userName}
       userEmail={member.userEmail}
-      isAdmin={isAdmin}
+      userRole={member.role}
     />
   ));
 

--- a/app/[groupId]/_components/modal/modal-member-profile.tsx
+++ b/app/[groupId]/_components/modal/modal-member-profile.tsx
@@ -11,7 +11,7 @@ interface ModalMemberProfileProps {
   userImage: string;
   userName: string;
   userEmail: string;
-  isAdmin: boolean;
+  userRole: string;
 }
 
 function ModalMemberProfile({
@@ -19,7 +19,7 @@ function ModalMemberProfile({
   userImage,
   userName,
   userEmail,
-  isAdmin,
+  userRole,
 }: ModalMemberProfileProps) {
   const handleButtonClick = async () => {
     try {
@@ -61,7 +61,7 @@ function ModalMemberProfile({
 
             <div className="flex flex-col items-center justify-center gap-[8px]">
               <div className="flex items-center gap-[4px]">
-                {isAdmin && (
+                {userRole === "ADMIN" && (
                   <Image src={Crown} alt="왕관" width={20} height={20} />
                 )}
 

--- a/app/[groupId]/_components/modal/modal-task-list-name-edit.tsx
+++ b/app/[groupId]/_components/modal/modal-task-list-name-edit.tsx
@@ -119,7 +119,11 @@ function ModalTaskListNameEdit({
               <Button
                 btnSize="large"
                 btnStyle="solid"
-                disabled={!isDirty || editTaskListMutation.isPending}
+                disabled={
+                  !isDirty ||
+                  !taskListName.trim() ||
+                  editTaskListMutation.isPending
+                }
               >
                 {editTaskListMutation.isPending ? "수정 중..." : "수정하기"}
               </Button>


### PR DESCRIPTION
<!-- PR 제목은 커밋 메세지 컨벤션 형식으로 작성 -->

## 🏷️ 이슈 번호 #316

- close #316

## 🧱 작업 사항

- 프로필 모달에서 모든 멤버의 이름 옆에 왕관이 달리는 버그를 수정하였습니다.
     - admin에게만 달아주도록 수정하였습니다.
 - 할 일 목록명을 수정할 때 공백만 입력해도 수정이 가능한 버그를 수정하였습니다.
     - !trim() 조건을 추가하였습니다.


## 📸 결과물

## 💬 공유 포인트 및 논의 사항
