### PR TITLE
fix: httpOnly 서버 쿠키로 적용

### DIFF
--- a/app/(auth)/login/_components/login-form.tsx
+++ b/app/(auth)/login/_components/login-form.tsx
@@ -6,11 +6,11 @@ import PasswordInput from "@/components/input-field/password-input";
 import { useCustomOverlay } from "@/hooks/use-custom-overlay";
 import { login } from "@/lib/apis/auth";
 import { PostAuthSigninResponse } from "@/lib/apis/type";
+import { setCookie } from "@/lib/cookies/cookieAction";
 import { loginSchema } from "@/schemas/auth";
 import { LoginInputValue } from "@/type/user";
 import { yupResolver } from "@hookform/resolvers/yup";
 import { useMutation } from "@tanstack/react-query";
-import { setCookie } from "cookies-next";
 import { useRouter } from "next-nprogress-bar";
 import { useState } from "react";
 import { SubmitHandler, useForm } from "react-hook-form";
@@ -41,9 +41,9 @@ export default function LoginForm() {
       const response = (await login(data)) as PostAuthSigninResponse;
       return response;
     },
-    onSuccess: (response: PostAuthSigninResponse) => {
-      setCookie("accessToken", response.accessToken, { maxAge: 60 * 60 });
-      setCookie("refreshToken", response.refreshToken, {
+    onSuccess: async (response: PostAuthSigninResponse) => {
+      await setCookie("accessToken", response.accessToken, { maxAge: 60 * 60 });
+      await setCookie("refreshToken", response.refreshToken, {
         maxAge: 60 * 60 * 24 * 7,
       });
       // NOTE - 로그인 후 랜딩으로 리다이렉트를 위해 push 헤더 업데이트를 위해 refresh

--- a/app/(auth)/oauth/_components/auth-redirect.tsx
+++ b/app/(auth)/oauth/_components/auth-redirect.tsx
@@ -3,9 +3,9 @@
 import { oauthLogin } from "@/lib/apis/auth";
 import { myFetch } from "@/lib/apis/myFetch";
 import { GetGoogleTokenResponse } from "@/lib/apis/type";
+import { setCookie } from "@/lib/cookies/cookieAction";
 import { showToast } from "@/lib/show-toast";
 import { useMutation } from "@tanstack/react-query";
-import { setCookie } from "cookies-next";
 import { useRouter } from "next-nprogress-bar";
 import Image from "next/image";
 import { useSearchParams } from "next/navigation";
@@ -59,9 +59,9 @@ export default function AuthRedirect({ provider }: AuthRedirectProps) {
 
       return oauthLogin(state, finalCode, provider);
     },
-    onSuccess: (response) => {
-      setCookie("accessToken", response.accessToken, { maxAge: 60 * 60 });
-      setCookie("refreshToken", response.refreshToken);
+    onSuccess: async (response) => {
+      await setCookie("accessToken", response.accessToken, { maxAge: 60 * 60 });
+      await setCookie("refreshToken", response.refreshToken);
       router.push("/");
       router.refresh();
     },

--- a/app/(free-board)/boards/_components/article-ranking-chart.tsx
+++ b/app/(free-board)/boards/_components/article-ranking-chart.tsx
@@ -12,6 +12,7 @@ export default function ArticleRankingChart() {
     page: "1",
     keyword: "",
   });
+
   return (
     <ol className="mb-8 grid grid-flow-col grid-cols-1 grid-rows-10 gap-1.5 gap-x-10 rounded-xl border border-black border-opacity-10 bg-background-secondary p-5 text-text-primary dark:border dark:border-white dark:border-opacity-10 md:grid-cols-2 md:grid-rows-5">
       {articles.list.map((article, i) => (

--- a/app/mypage/_component/modal-secession.tsx
+++ b/app/mypage/_component/modal-secession.tsx
@@ -1,8 +1,8 @@
 import Modal from "@/components/modal/modal";
 import { deleteAccount } from "@/lib/apis/user";
+import { deleteCookie } from "@/lib/cookies/cookieAction";
 import { showToast } from "@/lib/show-toast";
 import { useMutation, useQueryClient } from "@tanstack/react-query";
-import { deleteCookie } from "cookies-next";
 import { useRouter } from "next-nprogress-bar";
 import Image from "next/image";
 import { toast } from "react-toastify";
@@ -28,10 +28,10 @@ export default function ModalSecession({ close }: ModalWarningProps) {
       });
       close();
     },
-    onSuccess: () => {
+    onSuccess: async () => {
       router.push("/");
-      deleteCookie("accessToken");
-      deleteCookie("refreshToken");
+      await deleteCookie("accessToken");
+      await deleteCookie("refreshToken");
       queryClient.invalidateQueries({ queryKey: ["getUser"] });
       router.refresh();
       toast.update("deleteAccount", {

--- a/components/header/components/modal-logout.tsx
+++ b/components/header/components/modal-logout.tsx
@@ -1,6 +1,6 @@
 import Modal from "@/components/modal/modal";
+import { deleteCookie } from "@/lib/cookies/cookieAction";
 import { useQueryClient } from "@tanstack/react-query";
-import { deleteCookie } from "cookies-next";
 import { useRouter } from "next-nprogress-bar";
 import { useCallback } from "react";
 
@@ -12,10 +12,10 @@ export default function ModalLogout({ close }: ModalLogoutProps) {
   const router = useRouter();
   const queryClient = useQueryClient();
 
-  const logout = useCallback(() => {
+  const logout = useCallback(async () => {
     router.push("/");
-    deleteCookie("accessToken");
-    deleteCookie("refreshToken");
+    await deleteCookie("accessToken");
+    await deleteCookie("refreshToken");
     queryClient.invalidateQueries({ queryKey: ["getUser"] });
     router.refresh();
     close();

--- a/components/header/header.tsx
+++ b/components/header/header.tsx
@@ -1,11 +1,10 @@
-import { hasCookie } from "cookies-next";
-import { cookies } from "next/headers";
+import { hasCookie } from "@/lib/cookies/cookieAction";
 
 import LoggedInHeader from "./logged-in-header";
 import NoneLoginHeader from "./none-login-header";
 
-export default function Header() {
-  const isLoggedIn = hasCookie("refreshToken", { cookies });
+export default async function Header() {
+  const isLoggedIn = await hasCookie("refreshToken");
 
   return (
     <header className="fixed left-0 right-0 top-0 z-40 h-[60px] w-full bg-background-secondary px-4">

--- a/components/landing/landing-header.tsx
+++ b/components/landing/landing-header.tsx
@@ -1,12 +1,11 @@
-import { hasCookie } from "cookies-next";
-import { cookies } from "next/headers";
+import { hasCookie } from "@/lib/cookies/cookieAction";
 import Image from "next/image";
 
 import LinkButton from "../button/link-button";
 import LoggedInButton from "./logged-in-button";
 
-export default function LandingHeader() {
-  const isLoggedIn = hasCookie("refreshToken", { cookies });
+export default async function LandingHeader() {
+  const isLoggedIn = await hasCookie("refreshToken");
 
   return (
     <section className="relative h-[547px] w-full xl:mx-auto xl:max-w-[1920px]">

--- a/lib/apis/user/index.ts
+++ b/lib/apis/user/index.ts
@@ -1,9 +1,9 @@
+import { getCookie } from "@/lib/cookies/cookieAction";
 import {
   ResetPasswordInputValue,
   SendEmailInputValue,
   UpdateUserInputValue,
 } from "@/type/user";
-import { getCookie } from "cookies-next";
 
 import instance from "../myFetch/instance";
 import {
@@ -26,7 +26,7 @@ export async function getUser(): Promise<GetUserResponse> {
 
 // NOTE - 유저가 포함한 그룹 조회
 export async function gerUserGroups(): Promise<GetUserGroups> {
-  const accessToken = getCookie("accessToken");
+  const accessToken = await getCookie("accessToken");
 
   const response = await fetch(
     `${process.env.NEXT_PUBLIC_KKOM_KKOM_URL}/user/groups`,

--- a/lib/cookies/cookieAction.ts
+++ b/lib/cookies/cookieAction.ts
@@ -1,0 +1,32 @@
+"use server";
+
+import { cookies } from "next/headers";
+
+async function cookieStore() {
+  const store = await cookies();
+  return store;
+}
+
+export async function getCookie(name: string) {
+  const store = await cookieStore();
+  return store.get(name)?.value;
+}
+
+export async function setCookie(
+  name: string,
+  value: string,
+  options?: { maxAge: number },
+) {
+  const store = await cookieStore();
+  store.set(name, value, { ...options, httpOnly: true });
+}
+
+export async function deleteCookie(name: string) {
+  const store = await cookieStore();
+  store.delete(name);
+}
+
+export async function hasCookie(name: string) {
+  const store = await cookieStore();
+  return store.has(name);
+}

--- a/package.json
+++ b/package.json
@@ -31,7 +31,6 @@
     "class-variance-authority": "^0.7.0",
     "classnames": "^2.5.1",
     "clsx": "^2.1.1",
-    "cookies-next": "^4.2.1",
     "embla-carousel-react": "^8.2.0",
     "framer-motion": "^11.3.21",
     "lodash-es": "^4.17.21",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -44,9 +44,6 @@ importers:
       clsx:
         specifier: ^2.1.1
         version: 2.1.1
-      cookies-next:
-        specifier: ^4.2.1
-        version: 4.2.1
       embla-carousel-react:
         specifier: ^8.2.0
         version: 8.2.0(react@18.3.1)
@@ -1976,9 +1973,6 @@ packages:
   '@types/connect@3.4.38':
     resolution: {integrity: sha512-K6uROf1LD88uDQqJCktA4yzL1YYAK6NgfsI0v/mTgyPKWsX1CnJ0XPSDhViejru1GcRkLWb8RlzFYJRqGUbaug==}
 
-  '@types/cookie@0.6.0':
-    resolution: {integrity: sha512-4Kh9a6B2bQciAhf7FSuMRRkUWecJgJu9nPnx3yzpsfXX/c50REIqpHY4C82bXP90qrLtXtkDxTZosYO3UpOwlA==}
-
   '@types/cross-spawn@6.0.6':
     resolution: {integrity: sha512-fXRhhUkG4H3TQk5dBhQ7m/JDdSNHKwR2BBia62lhwEIq9xGiQKLxd6LymNhn47SjXhsUEPmxi+PKw2OkW4LLjA==}
 
@@ -2831,9 +2825,6 @@ packages:
   cookie@0.6.0:
     resolution: {integrity: sha512-U71cyTamuh1CRNCfpGY6to28lxvNwPG4Guz/EVjgf3Jmzv0vlDp1atT9eS5dDjMYHucpHbWns6Lwf3BKz6svdw==}
     engines: {node: '>= 0.6'}
-
-  cookies-next@4.2.1:
-    resolution: {integrity: sha512-qsjtZ8TLlxCSX2JphMQNhkm3V3zIMQ05WrLkBKBwu50npBbBfiZWIdmSMzBGcdGKfMK19E0PIitTfRFAdMGHXg==}
 
   core-js-compat@3.38.1:
     resolution: {integrity: sha512-JRH6gfXxGmrzF3tZ57lFx97YARxCXPaMzPo6jELZhv88pBH5VXpQ+y0znKGlFnzuaihqhLbefxSJxWJMPtfDzw==}
@@ -8191,8 +8182,6 @@ snapshots:
     dependencies:
       '@types/node': 20.16.1
 
-  '@types/cookie@0.6.0': {}
-
   '@types/cross-spawn@6.0.6':
     dependencies:
       '@types/node': 20.16.1
@@ -9168,11 +9157,6 @@ snapshots:
 
   cookie@0.6.0: {}
 
-  cookies-next@4.2.1:
-    dependencies:
-      '@types/cookie': 0.6.0
-      cookie: 0.6.0
-
   core-js-compat@3.38.1:
     dependencies:
       browserslist: 4.23.3
@@ -9793,8 +9777,8 @@ snapshots:
       '@typescript-eslint/parser': 7.2.0(eslint@8.57.0)(typescript@5.5.4)
       eslint: 8.57.0
       eslint-import-resolver-node: 0.3.9
-      eslint-import-resolver-typescript: 3.6.1(@typescript-eslint/parser@7.2.0(eslint@8.57.0)(typescript@5.5.4))(eslint-import-resolver-node@0.3.9)(eslint-plugin-import@2.29.1)(eslint@8.57.0)
-      eslint-plugin-import: 2.29.1(@typescript-eslint/parser@7.2.0(eslint@8.57.0)(typescript@5.5.4))(eslint-import-resolver-typescript@3.6.1)(eslint@8.57.0)
+      eslint-import-resolver-typescript: 3.6.1(@typescript-eslint/parser@7.2.0(eslint@8.57.0)(typescript@5.5.4))(eslint-import-resolver-node@0.3.9)(eslint-plugin-import@2.29.1(@typescript-eslint/parser@7.18.0(eslint@8.57.0)(typescript@5.5.4))(eslint@8.57.0))(eslint@8.57.0)
+      eslint-plugin-import: 2.29.1(@typescript-eslint/parser@7.2.0(eslint@8.57.0)(typescript@5.5.4))(eslint-import-resolver-typescript@3.6.1(@typescript-eslint/parser@7.2.0(eslint@8.57.0)(typescript@5.5.4))(eslint-import-resolver-node@0.3.9)(eslint-plugin-import@2.29.1(@typescript-eslint/parser@7.18.0(eslint@8.57.0)(typescript@5.5.4))(eslint@8.57.0))(eslint@8.57.0))(eslint@8.57.0)
       eslint-plugin-jsx-a11y: 6.9.0(eslint@8.57.0)
       eslint-plugin-react: 7.35.0(eslint@8.57.0)
       eslint-plugin-react-hooks: 4.6.2(eslint@8.57.0)
@@ -9816,13 +9800,13 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  eslint-import-resolver-typescript@3.6.1(@typescript-eslint/parser@7.2.0(eslint@8.57.0)(typescript@5.5.4))(eslint-import-resolver-node@0.3.9)(eslint-plugin-import@2.29.1)(eslint@8.57.0):
+  eslint-import-resolver-typescript@3.6.1(@typescript-eslint/parser@7.2.0(eslint@8.57.0)(typescript@5.5.4))(eslint-import-resolver-node@0.3.9)(eslint-plugin-import@2.29.1(@typescript-eslint/parser@7.18.0(eslint@8.57.0)(typescript@5.5.4))(eslint@8.57.0))(eslint@8.57.0):
     dependencies:
       debug: 4.3.6
       enhanced-resolve: 5.17.1
       eslint: 8.57.0
-      eslint-module-utils: 2.8.1(@typescript-eslint/parser@7.2.0(eslint@8.57.0)(typescript@5.5.4))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.6.1(@typescript-eslint/parser@7.2.0(eslint@8.57.0)(typescript@5.5.4))(eslint-import-resolver-node@0.3.9)(eslint-plugin-import@2.29.1)(eslint@8.57.0))(eslint@8.57.0)
-      eslint-plugin-import: 2.29.1(@typescript-eslint/parser@7.2.0(eslint@8.57.0)(typescript@5.5.4))(eslint-import-resolver-typescript@3.6.1)(eslint@8.57.0)
+      eslint-module-utils: 2.8.1(@typescript-eslint/parser@7.2.0(eslint@8.57.0)(typescript@5.5.4))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.6.1(@typescript-eslint/parser@7.2.0(eslint@8.57.0)(typescript@5.5.4))(eslint-import-resolver-node@0.3.9)(eslint-plugin-import@2.29.1(@typescript-eslint/parser@7.18.0(eslint@8.57.0)(typescript@5.5.4))(eslint@8.57.0))(eslint@8.57.0))(eslint@8.57.0)
+      eslint-plugin-import: 2.29.1(@typescript-eslint/parser@7.18.0(eslint@8.57.0)(typescript@5.5.4))(eslint@8.57.0)
       fast-glob: 3.3.2
       get-tsconfig: 4.7.6
       is-core-module: 2.15.1
@@ -9843,14 +9827,14 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  eslint-module-utils@2.8.1(@typescript-eslint/parser@7.2.0(eslint@8.57.0)(typescript@5.5.4))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.6.1(@typescript-eslint/parser@7.2.0(eslint@8.57.0)(typescript@5.5.4))(eslint-import-resolver-node@0.3.9)(eslint-plugin-import@2.29.1)(eslint@8.57.0))(eslint@8.57.0):
+  eslint-module-utils@2.8.1(@typescript-eslint/parser@7.2.0(eslint@8.57.0)(typescript@5.5.4))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.6.1(@typescript-eslint/parser@7.2.0(eslint@8.57.0)(typescript@5.5.4))(eslint-import-resolver-node@0.3.9)(eslint-plugin-import@2.29.1(@typescript-eslint/parser@7.18.0(eslint@8.57.0)(typescript@5.5.4))(eslint@8.57.0))(eslint@8.57.0))(eslint@8.57.0):
     dependencies:
       debug: 3.2.7
     optionalDependencies:
       '@typescript-eslint/parser': 7.2.0(eslint@8.57.0)(typescript@5.5.4)
       eslint: 8.57.0
       eslint-import-resolver-node: 0.3.9
-      eslint-import-resolver-typescript: 3.6.1(@typescript-eslint/parser@7.2.0(eslint@8.57.0)(typescript@5.5.4))(eslint-import-resolver-node@0.3.9)(eslint-plugin-import@2.29.1)(eslint@8.57.0)
+      eslint-import-resolver-typescript: 3.6.1(@typescript-eslint/parser@7.2.0(eslint@8.57.0)(typescript@5.5.4))(eslint-import-resolver-node@0.3.9)(eslint-plugin-import@2.29.1(@typescript-eslint/parser@7.18.0(eslint@8.57.0)(typescript@5.5.4))(eslint@8.57.0))(eslint@8.57.0)
     transitivePeerDependencies:
       - supports-color
 
@@ -9881,7 +9865,7 @@ snapshots:
       - eslint-import-resolver-webpack
       - supports-color
 
-  eslint-plugin-import@2.29.1(@typescript-eslint/parser@7.2.0(eslint@8.57.0)(typescript@5.5.4))(eslint-import-resolver-typescript@3.6.1)(eslint@8.57.0):
+  eslint-plugin-import@2.29.1(@typescript-eslint/parser@7.2.0(eslint@8.57.0)(typescript@5.5.4))(eslint-import-resolver-typescript@3.6.1(@typescript-eslint/parser@7.2.0(eslint@8.57.0)(typescript@5.5.4))(eslint-import-resolver-node@0.3.9)(eslint-plugin-import@2.29.1(@typescript-eslint/parser@7.18.0(eslint@8.57.0)(typescript@5.5.4))(eslint@8.57.0))(eslint@8.57.0))(eslint@8.57.0):
     dependencies:
       array-includes: 3.1.8
       array.prototype.findlastindex: 1.2.5
@@ -9891,7 +9875,7 @@ snapshots:
       doctrine: 2.1.0
       eslint: 8.57.0
       eslint-import-resolver-node: 0.3.9
-      eslint-module-utils: 2.8.1(@typescript-eslint/parser@7.2.0(eslint@8.57.0)(typescript@5.5.4))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.6.1(@typescript-eslint/parser@7.2.0(eslint@8.57.0)(typescript@5.5.4))(eslint-import-resolver-node@0.3.9)(eslint-plugin-import@2.29.1)(eslint@8.57.0))(eslint@8.57.0)
+      eslint-module-utils: 2.8.1(@typescript-eslint/parser@7.2.0(eslint@8.57.0)(typescript@5.5.4))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.6.1(@typescript-eslint/parser@7.2.0(eslint@8.57.0)(typescript@5.5.4))(eslint-import-resolver-node@0.3.9)(eslint-plugin-import@2.29.1(@typescript-eslint/parser@7.18.0(eslint@8.57.0)(typescript@5.5.4))(eslint@8.57.0))(eslint@8.57.0))(eslint@8.57.0)
       hasown: 2.0.2
       is-core-module: 2.15.1
       is-glob: 4.0.3


### PR DESCRIPTION
<!-- PR 제목은 커밋 메세지 컨벤션 형식으로 작성 -->

## 🏷️ 이슈 번호 #323 

- close #323 

## 🧱 작업 사항
- cookies-next 패키지를 삭제하였습니다.
- 쿠키 관련 로직을 서버 쿠키를 사용하는 서버 액션으로 변경하였습니다.
- 서버 쿠키를 저장할 때 httpOnly를 적용하였습니다.

## 📸 결과물

## 💬 공유 포인트 및 논의 사항